### PR TITLE
WIP: refact(driver): set driver name as rawfile.csi.openebs.io

### DIFF
--- a/.ci/e2e-test/rawfile-driver.yaml
+++ b/.ci/e2e-test/rawfile-driver.yaml
@@ -3,7 +3,7 @@ StorageClass:
 SnapshotClass:
   FromName: true
 DriverInfo:
-  Name: rawfile.hamravesh.com
+  Name: rawfile.csi.openebs.io
   SupportedFsType:
     ext4:
     btrfs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8.3-slim-buster
 WORKDIR /app/
 
 RUN apt-get update && \
-    apt-get install -y e2fsprogs btrfs-progs && \
+    apt-get install -y e2fsprogs xfsprogs btrfs-progs && \
     rm -rf /var/lib/apt/lists/*
 
 ENV PIP_NO_CACHE_DIR 1

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: my-sc
-provisioner: rawfile.hamravesh.com
+provisioner: rawfile.csi.openebs.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true

--- a/deploy/charts/rawfile-csi/templates/00-driver.yaml
+++ b/deploy/charts/rawfile-csi/templates/00-driver.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
-  name: rawfile.hamravesh.com
+  name: rawfile.csi.openebs.io
 spec:
   attachRequired: false
   podInfoOnMount: true

--- a/deploy/yaml/example-pod.yaml
+++ b/deploy/yaml/example-pod.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  namespace: default
+spec:
+  containers:
+  - command:
+       - sh
+       - -c
+       - 'date >> /mnt/store1/date.txt; hostname >> /mnt/store1/hostname.txt; sync; sleep 5; sync; tail -f /dev/null;'
+    image: busybox
+    imagePullPolicy: Always
+    name: busybox
+    volumeMounts:
+    - mountPath: /mnt/store1
+      name: demo-vol1
+  volumes:
+  - name: demo-vol1
+    persistentVolumeClaim:
+      claimName: demo-vol1-claim
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-vol1-claim
+spec:
+  storageClassName: openebs-rawfile
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G

--- a/deploy/yaml/rawfile-csi.yaml
+++ b/deploy/yaml/rawfile-csi.yaml
@@ -1,0 +1,351 @@
+---
+# Source: rawfile-csi/templates/00-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rawfile-csi-driver
+  namespace: kube-system
+---
+# Source: rawfile-csi/templates/00-rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rawfile-csi-provisioner
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: rawfile-csi/templates/00-rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rawfile-csi-broker
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+# Source: rawfile-csi/templates/00-rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rawfile-csi-resizer
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+---
+# Source: rawfile-csi/templates/00-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rawfile-csi-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: rawfile-csi-driver
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: rawfile-csi-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: rawfile-csi/templates/00-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rawfile-csi-broker
+subjects:
+  - kind: ServiceAccount
+    name: rawfile-csi-driver
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: rawfile-csi-broker
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: rawfile-csi/templates/00-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rawfile-csi-resizer
+subjects:
+  - kind: ServiceAccount
+    name: rawfile-csi-driver
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: rawfile-csi-resizer
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: rawfile-csi/templates/01-controller-plugin.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: rawfile-csi-controller
+  namespace: kube-system
+  labels:
+    helm.sh/chart: rawfile-csi-0.1.6
+    app.kubernetes.io/name: rawfile-csi
+    app.kubernetes.io/instance: rawfile-csi
+    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/managed-by: Helm
+    component: controller
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: rawfile-csi
+    app.kubernetes.io/instance: rawfile-csi
+    component: controller
+  clusterIP: None
+---
+# Source: rawfile-csi/templates/01-node-plugin.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: rawfile-csi-node
+  namespace: kube-system
+  labels:
+    helm.sh/chart: rawfile-csi-0.1.6
+    app.kubernetes.io/name: rawfile-csi
+    app.kubernetes.io/instance: rawfile-csi
+    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/managed-by: Helm
+    component: node
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: 9100
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: rawfile-csi
+    app.kubernetes.io/instance: rawfile-csi
+    component: node
+---
+# Source: rawfile-csi/templates/01-node-plugin.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: rawfile-csi-node
+  namespace: kube-system
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: "100%"
+  selector:
+    matchLabels: &selectorLabels
+      app.kubernetes.io/name: rawfile-csi
+      app.kubernetes.io/instance: rawfile-csi
+      component: node
+  template:
+    metadata:
+      labels: *selectorLabels
+    spec:
+      serviceAccount: rawfile-csi-driver
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: "Exists"
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/rawfile-csi
+            type: DirectoryOrCreate
+        - name: mountpoint-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: DirectoryOrCreate
+        - name: data-dir
+          hostPath:
+            path: /var/csi/rawfile
+            type: DirectoryOrCreate
+      containers:
+        - name: csi-driver
+          image: "docker.io/openebs/rawfile-localpv:c895312-ci"
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: IMAGE_REPOSITORY
+              value: "docker.io/openebs/rawfile-localpv"
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          ports:
+            - name: metrics
+              containerPort: 9100
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: mountpoint-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: data-dir
+              mountPath: /data
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 100Mi
+        - name: node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    rm -rf /registration/rawfile-csi /csi/csi.sock
+          args:
+            - --v=5
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/rawfile-csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+---
+# Source: rawfile-csi/templates/01-controller-plugin.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: rawfile-csi-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  serviceName: rawfile-csi
+  selector:
+    matchLabels: &selectorLabels
+      app.kubernetes.io/name: rawfile-csi
+      app.kubernetes.io/instance: rawfile-csi
+      component: controller
+  template:
+    metadata:
+      labels: *selectorLabels
+    spec:
+      serviceAccount: rawfile-csi-driver
+      priorityClassName: system-cluster-critical
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+      containers:
+        - name: csi-driver
+          image: "docker.io/openebs/rawfile-localpv:c895312-ci"
+          imagePullPolicy: Always
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: IMAGE_REPOSITORY
+              value: "docker.io/openebs/rawfile-localpv"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 100Mi
+        - name: csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--feature-gates=Topology=true"
+            - "--strict-topology"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-resizer
+          image: quay.io/k8scsi/csi-resizer:v0.5.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+---
+# Source: rawfile-csi/templates/00-driver.yaml
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: rawfile.csi.openebs.io
+spec:
+  attachRequired: false
+  podInfoOnMount: true
+  volumeLifecycleModes:
+    - Persistent
+---

--- a/deploy/yaml/rawfile-csi.yaml
+++ b/deploy/yaml/rawfile-csi.yaml
@@ -208,7 +208,7 @@ spec:
             type: DirectoryOrCreate
       containers:
         - name: csi-driver
-          image: "docker.io/openebs/rawfile-localpv:c895312-ci"
+          image: "docker.io/openebs/rawfile-localpv:ci-3e0a780"
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -217,6 +217,8 @@ spec:
               value: unix:///csi/csi.sock
             - name: IMAGE_REPOSITORY
               value: "docker.io/openebs/rawfile-localpv"
+            - name: IMAGE_TAG
+              value: "ci-3e0a780"
             - name: NODE_ID
               valueFrom:
                 fieldRef:
@@ -296,13 +298,15 @@ spec:
           emptyDir: {}
       containers:
         - name: csi-driver
-          image: "docker.io/openebs/rawfile-localpv:c895312-ci"
+          image: "docker.io/openebs/rawfile-localpv:ci-3e0a780"
           imagePullPolicy: Always
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             - name: IMAGE_REPOSITORY
               value: "docker.io/openebs/rawfile-localpv"
+            - name: IMAGE_TAG
+              value: "ci-3e0a780"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/deploy/yaml/sc.yaml
+++ b/deploy/yaml/sc.yaml
@@ -6,3 +6,5 @@ provisioner: rawfile.csi.openebs.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
+parameters:
+  fstype: xfs

--- a/deploy/yaml/sc.yaml
+++ b/deploy/yaml/sc.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-rawfile
+provisioner: rawfile.csi.openebs.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true

--- a/rawfile_servicer.py
+++ b/rawfile_servicer.py
@@ -19,7 +19,7 @@ class RawFileIdentityServicer(csi_pb2_grpc.IdentityServicer):
     @log_grpc_request
     def GetPluginInfo(self, request, context):
         return csi_pb2.GetPluginInfoResponse(
-            name="rawfile.hamravesh.com", vendor_version="0.0.1"
+            name="rawfile.csi.openebs.io", vendor_version="0.0.1"
         )
 
     @log_grpc_request

--- a/remote.py
+++ b/remote.py
@@ -37,6 +37,8 @@ def init_rawfile(volume_id, size, fs_type):
     run(f"truncate -s {size} {img_file}")
     if fs_type == "ext4":
         run(f"mkfs.ext4 {img_file}")
+    elif fs_type == "xfs":
+        run(f"mkfs.xfs {img_file}")
     elif fs_type == "btrfs":
         run(f"mkfs.btrfs {img_file}")
     else:


### PR DESCRIPTION
Completed:
- Updated the driver default name to rawfile.csi.openebs.io. 
- Added YAMLs to setup rawfile-csi driver using kubectl. The YAML is generated via `helm template` command.

Pending Tasks: 
- Make the provisioner name configurable via the helm value. 
- Change the docker image in yaml to pull master instead of ci. 

Signed-off-by: kmova <kiran.mova@mayadata.io>