### PR TITLE
Fix minor issues related to resources

### DIFF
--- a/deploy/charts/rawfile-csi/Chart.yaml
+++ b/deploy/charts/rawfile-csi/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: rawfile-csi
 description: RawFile Driver Container Storage Interface
 type: application
-version: 0.4.11
+version: 0.4.12

--- a/deploy/charts/rawfile-csi/templates/01-node-plugin.yaml
+++ b/deploy/charts/rawfile-csi/templates/01-node-plugin.yaml
@@ -116,3 +116,10 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          resources:
+            limits:
+              cpu: 500m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 100Mi

--- a/templates/task.yaml
+++ b/templates/task.yaml
@@ -22,9 +22,9 @@ spec:
         - name: data-dir
           mountPath: /data
       resources:
-        requests: &rsc
-          cpu: 10m
-          memory: 100Mi
+        requests:
+          cpu: 0m
+          memory: 0Mi
         limit:
           cpu: 100m
           memory: 100Mi

--- a/templates/task.yaml
+++ b/templates/task.yaml
@@ -25,7 +25,7 @@ spec:
         requests:
           cpu: 0m
           memory: 0Mi
-        limit:
+        limits:
           cpu: 100m
           memory: 100Mi
       command:


### PR DESCRIPTION
What this PR does:
- Adds `resources` to sidecar containers in chart in order to limit sidecar containers as well.
- Removes `requests` from task pods so that pods don't get stuck in pending state and pvcs are able to resize successfully.