### PR TITLE
add arm64 support

### DIFF
--- a/.ci/common
+++ b/.ci/common
@@ -5,6 +5,7 @@ slugify() {
   echo "$1" | sed -r 's/[^.a-zA-Z0-9]+/-/g'
 }
 
+export ARCH=`uname -m`
 export IMAGE="openebs/rawfile-localpv"
 export COMMIT=$(git rev-parse --short HEAD)
 export BRANCH=${TRAVIS_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
@@ -12,7 +13,7 @@ export BRANCH_SLUG=$(slugify $BRANCH)
 
 export CI_REGISTRY="docker.io"
 export CI_TAG="${COMMIT}-ci"
-export CI_IMAGE_REPO="${CI_REGISTRY}/${IMAGE}"
+export CI_IMAGE_REPO="${CI_REGISTRY}/${IMAGE}-${ARCH}"
 export CI_IMAGE_URI="${CI_IMAGE_REPO}:${CI_TAG}"
 
 function TagAndPushImage() {

--- a/.ci/e2e-test/setup.sh
+++ b/.ci/e2e-test/setup.sh
@@ -9,6 +9,7 @@ sudo apt update && sudo apt install -y conntrack
 curl -Lo minikube https://storage.googleapis.com/minikube/releases/v${MINIKUBE_VERSION}/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
 mkdir -p $HOME/.kube $HOME/.minikube
 touch $KUBECONFIG
+sudo systemctl enable docker.service
 sudo minikube start --profile=minikube --vm-driver=none --kubernetes-version=v${K8S_VERSION}
 minikube update-context --profile=minikube
 eval "$(minikube docker-env --profile=minikube)" && export DOCKER_CLI='docker'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 os: linux
+services:
+  - docker
+
 dist: bionic
 language: minimal
 jobs:
@@ -17,4 +20,22 @@ jobs:
         - CHANGE_MINIKUBE_NONE_USER=true
         - KUBECONFIG=$HOME/.kube/config
     - stage: publish
+      script: ./.ci/publish.sh
+    - stage: build-arm
+      arch: arm64
+      script: ./.ci/build.sh
+    - stage: e2e-test-arm
+      arch: arm64
+      install: ./.ci/e2e-test/setup.sh
+      if: tag IS present OR commit_message =~ /perform-e2e/
+      script: ./.ci/e2e-test/test.sh
+      env:
+        - CHANGE_MINIKUBE_NONE_USER=true
+        - MINIKUBE_WANTUPDATENOTIFICATION=false
+        - MINIKUBE_WANTREPORTERRORPROMPT=false
+        - MINIKUBE_HOME=$HOME
+        - CHANGE_MINIKUBE_NONE_USER=true
+        - KUBECONFIG=$HOME/.kube/config
+    - stage: publish-arm
+      arch: arm64
       script: ./.ci/publish.sh


### PR DESCRIPTION
The following file has been created and modified:

Added support for arm64 in .travis.yml to make docker images and publish them on docker hub.

**Note:** I have not added the e2e-testing for the arm64 platform because e2e-testing [requires minikube](https://github.com/odidev/rawfile-localpv/blob/0eb4eefd13aca1b3dd5a3e102ec43c1b91509393/.ci/e2e-test/setup.sh#L13) to run on travis for arm64 platform. And travisCI does not support minikube on the arm64 platform. There is an [open issue](https://github.com/kubernetes/minikube/issues/11845) for this in kubernetes/minikube.

Signed-off-by: odidev odidev@puresoftware.com