### PR TITLE
add mkfs nodiscard option to accelerate disk formatting phase

### DIFF
--- a/declarative.py
+++ b/declarative.py
@@ -70,9 +70,9 @@ def current_fs(device):
 def be_formatted(dev, fs):
     def init_fs(device):
         if fs == "ext4":
-            run(f"mkfs.ext4 -m 0 {device}")
+            run(f"mkfs.ext4 -m 0 -E nodiscard {device}")
         elif fs == "btrfs":
-            run(f"mkfs.btrfs {device}")
+            run(f"mkfs.btrfs -K {device}")
             tmp_mnt = tempfile.mkdtemp(prefix="mnt-")
             default_subvol = f"{tmp_mnt}/default"
             run(
@@ -87,7 +87,7 @@ def be_formatted(dev, fs):
                 """
             )
         elif fs == "xfs":
-            run(f"mkfs.xfs {device}")
+            run(f"mkfs.xfs -K {device}")
         else:
             raise Exception(f"Unsupported fs type: {fs}")
 


### PR DESCRIPTION
Some disk backends support `discard` feature to release unused blocks on underlying storage.
It will take a long time to discard blocks when using `mkfs` to format, if large "rawfile" is created on these storages.

This patch adds `-E nodiscard / -K` parameter to `mkfs.xxx` to accelerate "rawfile" formatting phase.