### PR TITLE
✨ feat: add stroage-class to helm chart

### DIFF
--- a/deploy/charts/rawfile-csi/templates/01-storage-class.yaml
+++ b/deploy/charts/rawfile-csi/templates/01-storage-class.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.storageClass.enabled }} 
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ include "rawfile-csi.fullname" . }} 
+provisioner: {{ .Values.provisionerName }}
+reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
+volumeBindingMode: {{ .Values.storageClass.volumeBindingMode }}
+allowVolumeExpansion: true
+{{- end }}

--- a/deploy/charts/rawfile-csi/values.yaml
+++ b/deploy/charts/rawfile-csi/values.yaml
@@ -25,3 +25,8 @@ imagePullSecrets: []
 serviceMonitor:
   enabled: true
   interval: 1m
+
+storageClass:
+  enabled: true
+  volumeBindingMode: WaitForFirstConsumer
+  reclaimPolicy: Delete


### PR DESCRIPTION
Adding StorageClass to Helm Chart will make this chart to be a great all in one setup for provisioning cluster storages

I also wanted to make helm chart docs to automatically generated using https://github.com/norwoodj/helm-docs
and also using GitHub Actions as a helm repo will remove the need of the cloning project to install its chart, If you are Okay with them I would love to work on them :)
Also I want to make the host path for data dir customizable