### PR TITLE
Fix xfs expansion bug

### DIFF
--- a/declarative.py
+++ b/declarative.py
@@ -109,6 +109,6 @@ def be_fs_expanded(dev, path):
     elif fs == "btrfs":
         run(f"btrfs filesystem resize max {path}")
     elif fs == "xfs":
-        run(f"xfs_growfs -d {dev}")
+        run(f"xfs_growfs -d {path}")
     else:
         raise Exception(f"Unsupported fsType: {fs}")


### PR DESCRIPTION
The `xfs_growfs` utility requires the path of a mounted XFS filesystem, not the device path, to perform an expansion.

#### Previous Behavior

```bash
$ xfs_growfs -d device

xfs_growfs: device is not a mounted XFS filesystem
```