### PR TITLE
fix: support direct-io for non-512 sector disk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.11-slim-buster as builder
+FROM python:3.11-slim-bookworm as builder
 RUN apt-get update && apt-get install -y build-essential libbtrfsutil-dev
 RUN pip wheel -w /wheels "https://github.com/kdave/btrfs-progs/archive/refs/tags/v6.3.2.tar.gz#egg=btrfsutil&subdirectory=libbtrfsutil/python"
 
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 
 WORKDIR /app/
 


### PR DESCRIPTION
fix: #39

upgrade baseos from buster to bookworm.

`losetup` from `util-linux` should include https://github.com/util-linux/util-linux/commit/a1a41597bfd55e709024bd91aaf024159362679c , in order to support dio for non-512 sector disk (4k sectors).

