### PR TITLE
chore: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default code owners
-*                           @openebs/localpv-rawfile-approvers @openebs/org-maintainers
+*                           @openebs/localpv-rawfile-approvers
 
 # CODEOWNERS file owners
 /.github/CODEOWNERS         @openebs/org-maintainers


### PR DESCRIPTION
Change:
- Remove requirement for an @openebs/org-maintainers member's review when merging non-policy documents.
- Settings changes:
   - Mandate code owner approval
   - Ensure required approval is set to 1

Fixes https://github.com/openebs/rawfile-localpv/issues/48