### PR TITLE
ci: remove deprecated magic nix

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -10,7 +10,6 @@ jobs:
         with:
           submodules: 'recursive'
       - uses: DeterminateSystems/nix-installer-action@v16
-      - uses: DeterminateSystems/magic-nix-cache-action@v9
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -22,7 +22,6 @@ jobs:
             git fetch -f origin ${{ github.ref }}:${{ github.ref }}
           fi
       - uses: DeterminateSystems/nix-installer-action@v16
-      - uses: DeterminateSystems/magic-nix-cache-action@v9
       - name: Pre-populate nix-shell
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v16
         with:
           kvm: true
-      - uses: DeterminateSystems/magic-nix-cache-action@v9
       - name: Setup Nix Path
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)


### PR DESCRIPTION
Looks like GitHub is removing the api which allows the magic action to use the GH cache.
For more details: https://dtr.mn/magic-nix-cache-eol