### PR TITLE
Fix helper task namespace and registry

### DIFF
--- a/.ci/e2e-test/test.sh
+++ b/.ci/e2e-test/test.sh
@@ -32,12 +32,14 @@ fi
 ./ginkgo -p -v \
   -focus='External.Storage' \
   -skip='\[Feature:|\[Disruptive\]|\[Serial\]' \
+  --fail-fast \
   ./e2e.test \
   -- \
   -storage.testdriver=rawfile-driver.yaml
 
 ./ginkgo -v \
   -focus='External.Storage.*(\[Feature:|\[Disruptive\]|\[Serial\])' \
+  --fail-fast \
   ./e2e.test \
   -- \
   -storage.testdriver=rawfile-driver.yaml

--- a/deploy/charts/rawfile-csi/templates/_helpers.tpl
+++ b/deploy/charts/rawfile-csi/templates/_helpers.tpl
@@ -92,6 +92,10 @@ Some helpers to handle image global information
 {{- printf "%s" $imageTag }}
 {{- end }}
 
+{{- define "rawfile-csi.node-image-registry" -}}
+{{- printf "%s" .Values.image.registry | default .Values.global.imageRegistry }}
+{{- end }}
+
 {{- define "rawfile-csi.node-image-repository" -}}
 {{- printf "%s" .Values.node.image.repository | default .Values.image.repository }}
 {{- end }}

--- a/deploy/charts/rawfile-csi/templates/controller/statefulset.yaml
+++ b/deploy/charts/rawfile-csi/templates/controller/statefulset.yaml
@@ -34,12 +34,14 @@ spec:
               value: unix:///csi/csi.sock
             - name: NODE_DATADIR
               value: "{{ .Values.node.dataDirPath }}"
+            - name: IMAGE_REGISTRY
+              value: "{{ include "rawfile-csi.node-image-registry" . }}"
             - name: IMAGE_REPOSITORY
               value: "{{ include "rawfile-csi.controller-image-repository" . }}"
-          {{- if regexMatch "^.*-ci$" (include "rawfile-csi.controller-image-tag" .) }}
             - name: IMAGE_TAG
               value: "{{ include "rawfile-csi.controller-image-tag" . }}"
-          {{- end }}
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/deploy/charts/rawfile-csi/templates/node-plugin/daemonset.yaml
+++ b/deploy/charts/rawfile-csi/templates/node-plugin/daemonset.yaml
@@ -48,12 +48,12 @@ spec:
               value: "{{ .Values.node.dataDirPath }}"
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
+            - name: IMAGE_REGISTRY
+              value: "{{ include "rawfile-csi.node-image-registry" . }}"
             - name: IMAGE_REPOSITORY
               value: "{{ include "rawfile-csi.node-image-repository" . }}"
-          {{- if regexMatch "^.*-ci$" (include "rawfile-csi.node-image-tag" .) }}
             - name: IMAGE_TAG
               value: "{{ include "rawfile-csi.node-image-tag" . }}"
-          {{- end }}
             - name: NODE_ID
               valueFrom:
                 fieldRef:
@@ -63,6 +63,8 @@ spec:
               value: {{ .Values.metrics.enabled | toString | quote }}
             - name: METRICS_PORT
               value: {{ .Values.metrics.port | toString | quote }}
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
           ports:
             - name: metrics
               containerPort: {{ .Values.metrics.port }}

--- a/rawfile/orchestrator/k8s.py
+++ b/rawfile/orchestrator/k8s.py
@@ -44,12 +44,14 @@ def wait_for(pred, desc=""):
 
 def run_on_node(fn, node):
     name = f"task-{uuid.uuid4()}"
+    registry = CONFIG["image_registry"]
+    repository = CONFIG["image_repository"]
     ctx = {
         "name": name,
-        "namespace": "kube-system",  # FIXME
+        "namespace": CONFIG["namespace"],
         "nodeSelector": json.dumps({"kubernetes.io/hostname": node}),
         "cmd": json.dumps(fn),
-        "image_repository": CONFIG["image_repository"],
+        "image_repository": f"{registry}/{repository}" if registry is not None else repository,
         "image_tag": CONFIG["image_tag"],
         "datadir": CONFIG["node_datadir"]
     }

--- a/rawfile/rawfile.py
+++ b/rawfile/rawfile.py
@@ -14,13 +14,17 @@ from rawfile_util import migrate_all_volume_schemas, gc_all_volumes
 
 
 @click.group()
+@click.option("--image-registry", envvar="IMAGE_REGISTRY")
 @click.option("--image-repository", envvar="IMAGE_REPOSITORY")
 @click.option("--image-tag", envvar="IMAGE_TAG")
 @click.option("--node-datadir", envvar="NODE_DATADIR")
-def cli(image_repository, image_tag, node_datadir):
+@click.option("--namespace", envvar="NAMESPACE")
+def cli(image_registry, image_repository, image_tag, node_datadir, namespace):
+    CONFIG["image_registry"] = image_registry
     CONFIG["image_repository"] = image_repository
     CONFIG["image_tag"] = image_tag
     CONFIG["node_datadir"] = node_datadir
+    CONFIG["namespace"] = namespace
 
 
 @cli.command()


### PR DESCRIPTION
    fix(template): add missing registry and namespace
    
    The template task for `run_on_node` commands was not using the correct
    image registry nor namespace.
    This was seen when using a default registry, ex: localhost:5000
    
---

    test: run ginkgo with fail fast
    
    Allows for faster debug triage iterations.
