### PR TITLE
build: use shell python for poetry

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -21,6 +21,7 @@ pkgs.mkShell {
   ] ++ pkgs.lib.optional (builtins.getEnv "IN_NIX_SHELL" == "pure") [ docker-client ];
   shellHook = ''
     export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib"
+    poetry env use $(which python)
     poetry install
     source $(poetry env info -p)/bin/activate
     pre-commit install


### PR DESCRIPTION
Since we are using a different python version than the one which comes packaged with poetry, we ensure it's set.