### PR TITLE
feat(mode/block): add block mode support

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -37,3 +37,7 @@ docker buildx build \
   --build-arg "IMAGE_REPOSITORY=${IMAGE}" \
   --build-arg "IMAGE_TAG=${COMMIT}" \
   "$SCRIPT_DIR/.."
+
+if [ "$(kubectl config current-context)" = "kind-rawfile" ]; then
+  kind load docker-image $(build-image-uri ${CI_TEST_IMAGE_TAG}) --name "rawfile"
+fi

--- a/.ci/deployer.sh
+++ b/.ci/deployer.sh
@@ -132,6 +132,12 @@ for node_index in $(seq 1 $WORKERS); do
   cat <<EOF >> "$TMP_KIND_CONFIG"
 - role: worker
   image: kindest/node:$K8S_VERSION
+  # kubeadmConfigPatches:
+  # - |
+  #   kind: JoinConfiguration
+  #   nodeRegistration:
+  #     kubeletExtraArgs:
+  #       v: "5"
   extraMounts:
     - hostPath: /dev
       containerPath: /dev

--- a/.ci/e2e-test/rawfile-driver.yaml
+++ b/.ci/e2e-test/rawfile-driver.yaml
@@ -10,7 +10,7 @@ DriverInfo:
     xfs:
   Capabilities:
     persistence: true
-    block: false
+    block: true
     fsGroup: true
     exec: true
     snapshotDataSource: false

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Features
   - ~~ReadWriteMany~~
 - [ ] Volume modes
   - [x] `Filesystem` mode
-  - [ ] `Block` mode
+  - [x] `Block` mode
 - [x] Volume metrics
 - [x] Supports fsTypes: `ext4`, `btrfs`, `xfs`
 - [x] Online expansion: If fs supports it (e.g. ext4, btrfs, xfs)

--- a/rawfile/bd2fs.py
+++ b/rawfile/bd2fs.py
@@ -17,7 +17,8 @@ from declarative import (
     be_mounted,
     be_unmounted,
 )
-from fs_util import mountpoint_to_dev, path_stats
+from fs_util import AccessType, mountpoint_to_dev, path_stats
+from rawfile_util import attached_loops
 from google.protobuf.timestamp_pb2 import Timestamp
 from remote import btrfs_create_snapshot, btrfs_delete_snapshot
 from util import log_grpc_request
@@ -28,6 +29,18 @@ def get_fs(request):
     if fs_type == "":
         fs_type = "ext4"
     return fs_type
+
+
+def get_access_type(request):
+    access_type = request.volume_capability.WhichOneof("access_type")
+    return check_access_type(access_type)
+
+
+def check_access_type(access_type):
+    try:
+        return AccessType[access_type]
+    except KeyError:
+        raise Exception(f"Unsupported access type: {access_type}")
 
 
 class Bd2FsIdentityServicer(csi_pb2_grpc.IdentityServicer):
@@ -58,8 +71,16 @@ class Bd2FsNodeServicer(csi_pb2_grpc.NodeServicer):
     @log_grpc_request
     def NodePublishVolume(self, request, context):
         staging_dev = f"{request.staging_target_path}/device"
-        Path(request.target_path).mkdir(exist_ok=True)
-        be_mounted(dev=staging_dev, mountpoint=request.target_path)
+
+        path = Path(request.target_path)
+        access_type_actions = {
+            AccessType.mount: path.mkdir,
+            AccessType.block: path.touch,
+        }
+        access_type_actions[get_access_type(request)](exist_ok=True)
+        be_mounted(
+            dev=staging_dev, mountpoint=request.target_path, readonly=request.readonly
+        )
         return csi_pb2.NodePublishVolumeResponse()
 
     @log_grpc_request
@@ -94,10 +115,11 @@ class Bd2FsNodeServicer(csi_pb2_grpc.NodeServicer):
 
         self.bds.NodePublishVolume(bd_publish_request, context)
 
-        mount_path = f"{request.staging_target_path}/mount"
-        Path(mount_path).mkdir(exist_ok=True)
-        be_formatted(dev=bd_publish_request.target_path, fs=get_fs(request))
-        be_mounted(dev=bd_publish_request.target_path, mountpoint=mount_path)
+        if get_access_type(request) is AccessType.mount:
+            mount_path = f"{request.staging_target_path}/mount"
+            Path(mount_path).mkdir(exist_ok=True)
+            be_formatted(dev=bd_publish_request.target_path, fs=get_fs(request))
+            be_mounted(dev=bd_publish_request.target_path, mountpoint=mount_path)
 
         return csi_pb2.NodeStageVolumeResponse()
 
@@ -125,6 +147,8 @@ class Bd2FsNodeServicer(csi_pb2_grpc.NodeServicer):
     # @log_grpc_request
     def NodeGetVolumeStats(self, request, context):
         volume_path = request.volume_path
+        if Path(volume_path).is_block_device():
+            return self.bds.NodeGetVolumeStats(request, context)
         stats = path_stats(volume_path)
         return csi_pb2.NodeGetVolumeStatsResponse(
             usage=[
@@ -145,6 +169,13 @@ class Bd2FsNodeServicer(csi_pb2_grpc.NodeServicer):
 
     @log_grpc_request
     def NodeExpandVolume(self, request, context):
+        if get_access_type(request) is AccessType.block:
+            dev = attached_loops(request.volume_path)[0]
+            request.volume_path = dev
+            self.bds.NodeExpandVolume(request, context)
+            size = request.capacity_range.required_bytes
+            return csi_pb2.NodeExpandVolumeResponse(capacity_bytes=size)
+
         # FIXME: hacky way to determine if `volume_path` is staged path,
         # or the mount itself
         # Based on CSI 1.4.0 specifications:
@@ -204,7 +235,7 @@ class Bd2FsControllerServicer(csi_pb2_grpc.ControllerServicer):
             )
 
         access_type = volume_capability.WhichOneof("access_type")
-        assert access_type == "mount"
+        check_access_type(access_type)
 
         bd_request = CreateVolumeRequest()
         bd_request.CopyFrom(request)

--- a/rawfile/declarative.py
+++ b/rawfile/declarative.py
@@ -31,7 +31,7 @@ def be_symlink(path, to):
     path.symlink_to(to)
 
 
-def be_mounted(dev, mountpoint):
+def be_mounted(dev, mountpoint, readonly=False):
     dev = Path(dev).resolve()
     mountpoint = Path(mountpoint)
 
@@ -40,6 +40,14 @@ def be_mounted(dev, mountpoint):
             return
         # noinspection PyUnreachableCode
         be_unmounted(mountpoint)
+    elif mountpoint.resolve().is_file():
+        opts = ["bind"]
+        # don't we need to add this?
+        if readonly:
+            opts.append("ro")
+        opts_str = ",".join(opts)
+        run(f"mount -t none -o {opts_str} -r {dev} {mountpoint}")
+        return
 
     fs = current_fs(dev)
     if fs == "ext4":

--- a/rawfile/fs_util.py
+++ b/rawfile/fs_util.py
@@ -1,6 +1,13 @@
 import json
 import os
 import subprocess
+from enum import Enum
+from pathlib import Path
+
+
+class AccessType(Enum):
+    mount = 1
+    block = 2
 
 
 def path_stats(path):
@@ -36,6 +43,7 @@ def dev_to_mountpoint(dev_name):
 
 
 def mountpoint_to_dev(mountpoint):
+    assert Path(mountpoint).is_dir()
     res = subprocess.run(
         f"findmnt --json --first-only --nofsroot --mountpoint {mountpoint}",
         shell=True,

--- a/rawfile/rawfile_servicer.py
+++ b/rawfile/rawfile_servicer.py
@@ -111,7 +111,10 @@ class RawFileNodeServicer(csi_pb2_grpc.NodeServicer):
     # @log_grpc_request
     def NodeGetVolumeStats(self, request, context):
         volume_path = request.volume_path
-        dev = mountpoint_to_dev(volume_path)
+        if Path(volume_path).is_block_device():
+            dev = volume_path
+        else:
+            dev = mountpoint_to_dev(volume_path)
         stats = device_stats(dev=dev)
         return csi_pb2.NodeGetVolumeStatsResponse(
             usage=[
@@ -163,16 +166,6 @@ class RawFileControllerServicer(csi_pb2_grpc.ControllerServicer):
                 grpc.StatusCode.INVALID_ARGUMENT,
                 f"Unsupported access mode: {AccessModeEnum.Name(volume_capability.access_mode.mode)}",
             )
-
-        # FIXME: re-enable access_type after bd2fs is fixed
-        # access_type = volume_capability.WhichOneof("access_type")
-        # if access_type == "block":
-        #     pass
-        # else:
-        #     context.abort(
-        #         grpc.StatusCode.INVALID_ARGUMENT,
-        #         "PANIC! This should be handled by bd2fs!",
-        #     )
 
         MIN_SIZE = 16 * 1024 * 1024  # 16MiB: can't format xfs with smaller volumes
         size = max(MIN_SIZE, request.capacity_range.required_bytes)


### PR DESCRIPTION
Since the rawfile's building block is a loop device, adding block mode support is relatively straightforward.

The node publish creates the target_path as a file, rather than a directory
The be_mounted, does a bind mount rather than a filesystem one The node stage ofc skips the formatting step
The volume stats collects only the device size
The node expand stops after loop device expansion