### PR TITLE
docs: add note for block volumes with RO

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Features
 - [ ] Volume modes
   - [x] `Filesystem` mode
   - [x] `Block` mode
+    - The `readOnly` attribute in the PVC template is not currently handled properly
 - [x] Volume metrics
 - [x] Supports fsTypes: `ext4`, `btrfs`, `xfs`
 - [x] Online expansion: If fs supports it (e.g. ext4, btrfs, xfs)


### PR DESCRIPTION
In order to support this with loop devices, the mount itself does not seem to be enough.
We likely need to create an additional loop device with RO set.