### PR TITLE
A few bugfixes

### DIFF
--- a/rawfile/declarative.py
+++ b/rawfile/declarative.py
@@ -42,11 +42,11 @@ def be_mounted(dev, mountpoint, readonly=False):
         be_unmounted(mountpoint)
     elif mountpoint.resolve().is_file():
         opts = ["bind"]
-        # don't we need to add this?
+        # todo: this is not sufficient, we need to create a separate loop device for RO
         if readonly:
             opts.append("ro")
         opts_str = ",".join(opts)
-        run(f"mount -t none -o {opts_str} -r {dev} {mountpoint}")
+        run(f"mount -t none -o {opts_str} {dev} {mountpoint}")
         return
 
     fs = current_fs(dev)

--- a/rawfile/rawfile_util.py
+++ b/rawfile/rawfile_util.py
@@ -115,6 +115,8 @@ def attach_loop(file) -> str:
             pfx_len = len("/dev/loop")
             loop_dev_id = loop_file[pfx_len:]
             run(f"mknod {loop_file} b 7 {loop_dev_id}")
+        # sometimes a RO attribute is sticky on the loop device, for some reason
+        run_out(f"blockdev --setrw {loop_file}")
         return loop_file
 
     while True:

--- a/rawfile/remote.py
+++ b/rawfile/remote.py
@@ -77,11 +77,11 @@ def expand_rawfile(volume_id, size):
     if rawfile_util.get_capacity() < size_inc:
         exit(RESOURCE_EXHAUSTED_EXIT_CODE)
 
+    rawfile_util.truncate(img_file, size)
     rawfile_util.patch_metadata(
         volume_id,
         {"size": size},
     )
-    rawfile_util.truncate(img_file, size)
 
 
 @contextmanager


### PR DESCRIPTION
    fix(resize): resize img file first

    Ensures idempotency in case of crash between metadata change
    and file truncate.

---

    fix: remove mistaken -r and set rw on loop

    Remove a -r left in the mount by mistaken (not that it makes
    any difference, since the loop's RW/RO is what dictates it).
    Ensure the created loop device RW/RO is correct as I've seen
    that sometimes it becomes sticky.