### PR TITLE
Loop Device fixes

### DIFF
--- a/deploy/charts/rawfile-csi/templates/node-plugin/daemonset.yaml
+++ b/deploy/charts/rawfile-csi/templates/node-plugin/daemonset.yaml
@@ -35,6 +35,10 @@ spec:
           hostPath:
             path: {{ .Values.node.dataDirPath }}
             type: DirectoryOrCreate
+        - name: device
+          hostPath:
+            path: /dev
+            type: Directory
       containers:
         - name: csi-driver
           image: "{{ include "rawfile-csi.node-image" . }}"
@@ -78,6 +82,8 @@ spec:
               mountPropagation: "Bidirectional"
             - name: data-dir
               mountPath: /data
+            - name: device
+              mountPath: /dev
           resources:
             {{- include "rawfile-csi.controller-resources" . | nindent 12 }}
         - name: node-driver-registrar

--- a/rawfile/rawfile_util.py
+++ b/rawfile/rawfile_util.py
@@ -115,16 +115,36 @@ def attach_loop(file) -> str:
             pfx_len = len("/dev/loop")
             loop_dev_id = loop_file[pfx_len:]
             run(f"mknod {loop_file} b 7 {loop_dev_id}")
-        # sometimes a RO attribute is sticky on the loop device, for some reason
-        run_out(f"blockdev --setrw {loop_file}")
         return loop_file
 
-    while True:
-        devs = attached_loops(file)
-        if len(devs) > 0:
-            return devs[0]
-        next_loop()
-        run(f"losetup --direct-io=on -f {file}")
+    # if multiple pods are getting staged at the same time, and there's not enough loop nodes, then we
+    # could clash on the creation, thus leading into losetup -f failures...
+    max_attempts = 20
+    for _ in range(max_attempts):
+        try:
+            devs = attached_loops(file)
+            if len(devs) > 0:
+                # we could use -L to ensure there's no overlap, and thus having
+                # only 1 device at most a match and allowing us to simply use
+                # losetup --direct-io=on -fL --show {file}
+                dev = devs[0]
+                # sometimes a RO attribute is sticky on the loop device, for some reason
+                run(f"blockdev --setrw {dev}")
+                return dev
+            next_loop()
+            run(f"losetup --direct-io=on -f {file}")
+        except Exception as e:
+            # todo: add some jitter here?
+            last_exception = e
+
+    if last_exception:
+        raise Exception(
+            f"Failed to attach loop device for {file} after {max_attempts} attempts: {last_exception}"
+        )
+    else:
+        raise Exception(
+            f"Failed to attach loop device for {file} after {max_attempts} attempts"
+        )
 
 
 def detach_loops(file) -> None:

--- a/rawfile/util.py
+++ b/rawfile/util.py
@@ -3,31 +3,39 @@ import functools
 import inspect
 import pickle
 import subprocess
+import time
 
 
 def indent(obj, lvl):
     return "\n".join([(lvl * " ") + line for line in str(obj).splitlines()])
 
 
+def fmt_timestamp(ts):
+    return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(ts))
+
+
 def log_grpc_request(func):
     @functools.wraps(func)
     def wrap(self, request, context):
+        start = time.time()
         try:
             res = func(self, request, context)
+            end = time.time()
             print(
-                f"""{func.__name__}({{
+                f"""{fmt_timestamp(end)} => {func.__name__}({{
 {indent(request, 2)}
 }}) = {{
 {indent(res, 2)}
-}}"""
+}} <= {fmt_timestamp(end)} // {(end - start) * 1000:.2f}ms"""
             )
             return res
         except Exception as exc:
             ret = (str(context._state.code), context._state.details)
+            end = time.time()
             print(
-                f"""{func.__name__}({{
+                f"""{fmt_timestamp(end)} => {func.__name__}({{
 {indent(request, 2)}
-}}) = {ret}
+}}) = {ret} <= {fmt_timestamp(end)} // {(end - start) * 1000:.2f}ms
 """
             )
             raise exc
@@ -35,12 +43,12 @@ def log_grpc_request(func):
     return wrap
 
 
-def run(cmd):
-    return subprocess.run(cmd, shell=True, check=True)
+def run(cmd, check=True):
+    return subprocess.run(cmd, shell=True, check=check)
 
 
-def run_out(cmd: str):
-    p = subprocess.run(cmd, shell=True, capture_output=True)
+def run_out(cmd: str, check=False):
+    p = subprocess.run(cmd, shell=True, check=check, capture_output=True)
     return p
 
 


### PR DESCRIPTION
    fix(loop): handle contention better

    In case of contention, don't fail right away and try up to 20 times.

---

    chore: add timestamp information to grpc traces

    Adds ts to begin and end, tracing duration of calls, ex:
    $start => NodeStage {
    ....
    } <= $end // 100ms

---

    fix(chart): add host dev mount to the csi node pod

    Otherwise, special block devices for the loop devices, which are created
    from the pod, would not be propagated to the host properly.
    This means even pod itself may stop seeing the devices after a pod restart.
