### PR TITLE
More fix

### DIFF
--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -35,6 +35,9 @@ jobs:
         run: nix-shell --run ".ci/e2e-test/setup.sh"
       - name: Run K8s tests
         run: nix-shell --run ".ci/e2e-test/test.sh"
+      - run: |
+          nix-shell --run "kubectl -n openebs logs -lcomponent=node -c csi-driver --tail=-1"
+          nix-shell --run "kubectl -n openebs logs -lcomponent=controller -c csi-driver --tail=-1"
       - name: Collect dump
         if: failure()
         run: |

--- a/deploy/charts/rawfile-csi/Chart.yaml
+++ b/deploy/charts/rawfile-csi/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rawfile-csi
 description: RawFile Driver Container Storage Interface
 type: application
-version: 0.9.0
-appVersion: 0.8.0
+version: 0.10.0
+appVersion: 0.10.0
 kubeVersion: ">= 1.21"
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/openebs/icon/color/openebs-icon-color.png
 home: https://openebs.io/

--- a/deploy/charts/rawfile-csi/README.md
+++ b/deploy/charts/rawfile-csi/README.md
@@ -1,6 +1,6 @@
 # rawfile-csi
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0](https://img.shields.io/badge/AppVersion-0.10.0-informational?style=flat-square)
 
 RawFile Driver Container Storage Interface
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rawfile"
-version = "0.8.0"
+version = "0.10.0"
 description = "Dynamically deploy Stateful Persistent Node-Local Volumes & Filesystems for Kubernetes that is provisioned from RAW-device file loop mounted Local-Hostpath storage."
 authors = ["OpenEBS <openebs-team@googlegroups.com>"]
 license = "apache"

--- a/rawfile/consts.py
+++ b/rawfile/consts.py
@@ -1,7 +1,7 @@
 import os
 
 PROVISIONER_NAME = os.getenv("PROVISIONER_NAME", "rawfile.csi.openebs.io")
-PROVISIONER_VERSION = "0.8.0"
+PROVISIONER_VERSION = "0.10.0"
 DATA_DIR = "/data"
 CONFIG = {}
 D_PERMS = 0o700

--- a/rawfile/rawfile_util.py
+++ b/rawfile/rawfile_util.py
@@ -22,8 +22,12 @@ def meta_file(volume_id):
 
 
 def metadata(volume_id):
+    return json.loads(meta_file(volume_id).read_text())
+
+
+def metadata_or(volume_id):
     try:
-        return json.loads(meta_file(volume_id).read_text())
+        return metadata(volume_id)
     except FileNotFoundError:
         return {}
 
@@ -41,7 +45,7 @@ def destroy(volume_id, dry_run=True):
 
 
 def gc_if_needed(volume_id, dry_run=True):
-    meta = metadata(volume_id)
+    meta = metadata_or(volume_id)
 
     deleted_at = meta.get("deleted_at", None)
     gc_at = meta.get("gc_at", None)
@@ -81,13 +85,13 @@ def update_permissions(volume_id: str) -> None:
 
 
 def patch_metadata(volume_id: str, obj: dict) -> dict:
-    old_data = metadata(volume_id)
+    old_data = metadata_or(volume_id)
     new_data = {**old_data, **obj}
     return update_metadata(volume_id, new_data)
 
 
 def migrate_metadata(volume_id, target_version):
-    old_data = metadata(volume_id)
+    old_data = metadata_or(volume_id)
     new_data = migrate_to(old_data, target_version)
     return update_metadata(volume_id, new_data)
 
@@ -172,12 +176,15 @@ def gc_all_volumes(dry_run=True):
 def get_volumes_stats() -> [dict]:
     volumes_stats = {}
     for volume_id in list_all_volumes():
-        file = img_file(volume_id=volume_id)
-        stats = file.stat()
-        volumes_stats[volume_id] = {
-            "used": stats.st_blocks * 512,
-            "total": stats.st_size,
-        }
+        try:
+            file = img_file(volume_id=volume_id)
+            stats = file.stat()
+            volumes_stats[volume_id] = {
+                "used": stats.st_blocks * 512,
+                "total": stats.st_size,
+            }
+        except FileNotFoundError:
+            pass
     return volumes_stats
 
 


### PR DESCRIPTION
    chore: bump version to 0.10.0

---

    ci: print logs on success

    This aids in inspecting results of successful runs.

---

    fix: race on create and stats

    Volume metadata is created ahead of the img file, which means a concurrent
    capacity call may find an error.

    Also there's no point supressing file not found only to then hit a key error
    exception.
    I'm not sure if the metadata management code needs to rely on this somehow,
    so keep this behaviour there but change it elsewhere.
