### PR TITLE
feat: graceful K8s termination

### DIFF
--- a/rawfile/rawfile.py
+++ b/rawfile/rawfile.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 import logging
 from concurrent import futures
-
+import signal
+import time
 import bd2fs
 import click
 import grpc
@@ -50,6 +51,22 @@ def csi_driver(endpoint, nodeid, enable_metrics, metrics_port):
         server,
     )
     server.add_insecure_port(endpoint)
+
+    def signal_handler(signum, frame: None):
+        grace_seconds = 20
+
+        print(f"Received termination request via signal: {signal.Signals(signum).name}")
+        print(f"Stopping the CSI server with a grace period of {grace_seconds} seconds")
+
+        start = time.time()
+        server.stop(grace_seconds)
+        elapsed = time.time() - start
+
+        print(f"CSI Server has stopped after {elapsed:.1f} seconds")
+
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+
     server.start()
     server.wait_for_termination()
 


### PR DESCRIPTION
When deleting the pod, we receive the SIGTERM signal and a default grace period of 30s after which we're force killed with SIGKILL. This change adds a handler for SIGTERM allows us to stop the csi server gracefully (if possible) and quickly terminate without having to wait.

Added SIGTERM handling as well, alongside with logs for information.

Resolves #108