### PR TITLE
fix: set tag with app version

### DIFF
--- a/deploy/helm/rawfile-localpv/templates/_helpers.tpl
+++ b/deploy/helm/rawfile-localpv/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Create the name of the service account to use
 Some helpers to handle image global information
 */}}
 {{- define "rawfile-localpv.controller-image-tag" -}}
-{{- $imageTag := .Values.controller.image.tag | default .Values.image.tag | default .Chart.AppVersion }}
+{{- $imageTag := .Values.controller.image.tag | default .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}
 {{- printf "%s" $imageTag }}
 {{- end }}
 


### PR DESCRIPTION
If tag is not specified we use the app version, so we need to add a v to the prefix.