### PR TITLE
test: increase kubelet sync frequency

### DIFF
--- a/.ci/deployer.sh
+++ b/.ci/deployer.sh
@@ -113,6 +113,11 @@ $SUDO rm -rf "$TMP_KIND"/*
 cat <<EOF > "$TMP_KIND_CONFIG"
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+kubeadmConfigPatches:
+- |
+  apiVersion: kubelet.config.k8s.io/v1beta1
+  kind: KubeletConfiguration
+  syncFrequency: 10s
 nodes:
 - role: control-plane
   image: kindest/node:$K8S_VERSION

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: pytest.log
+          name: smoke-pytest.log
           path: pytest.log
       - uses: pmeier/pytest-results-action@main
         if: always()
@@ -79,7 +79,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: k8s-dump
+          name: smoke-k8s-dump
           path: dump
 
   release-check:


### PR DESCRIPTION
We've identified that the reason why the expansion tests take longer than expected is the kubelet sync frequency, which is what specifies how often the container and config are synced.

A high sync frequency could impact performance, but these are test clusters it's probably not an issue.