### PR TITLE
ci: use storage from root (sda1)

### DIFF
--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -165,6 +165,7 @@ jobs:
           sudo debconf-communicate <<< "set man-db/auto-update false" || true
           sudo dpkg-reconfigure man-db || true
           nix-shell --run ".ci/deployer.sh start"
+          exit 1
       - name: Release Sanity Check
         if: ${{ inputs.release }}
         run: |
@@ -201,7 +202,7 @@ jobs:
         with:
           name: k8s-dump
           path: dump
-      # - name: Setup tmate session
-      #   if: ${{ failure() }}
-      #   timeout-minutes: 120
-      #   uses: mxschmitt/action-tmate@v3
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        timeout-minutes: 120
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -26,6 +26,7 @@ on:
 
 env:
   CI: 1
+  TMP_KIND: .ci/kind/rawfile/
 
 jobs:
   smoke:
@@ -35,9 +36,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - run: |
-          lsblk
-          df -h
       - uses: DeterminateSystems/nix-installer-action@v17
         with:
           kvm: true
@@ -49,15 +47,11 @@ jobs:
         run: nix-shell --run "echo"
       - name: Build test images
         run: nix-shell --run "CI_TEST=true .ci/build.sh"
-      - run: |
-          lsblk
-          df -h
       - name: BootStrap k8s cluster
         run: |
           sudo debconf-communicate <<< "set man-db/auto-update false" || true
           sudo dpkg-reconfigure man-db || true
-          sudo chown $USER /mnt
-          nix-shell --run "TMP_KIND=/mnt/kind/rawfile/ .ci/deployer.sh start"
+          nix-shell --run ".ci/deployer.sh start"
       - name: Run K8s tests
         run: nix-shell --run ".ci/smoke.sh"
       - run: |
@@ -79,8 +73,6 @@ jobs:
       - name: Collect dump
         if: failure()
         run: |
-          lsblk
-          df -h
           nix-shell --run "kind export logs ./dump/kind --name rawfile"
           nix-shell --run "kubectl cluster-info dump --output-directory=./dump/k8s --namespaces=openebs,kube-system"
       - name: Upload cluster dump
@@ -115,8 +107,7 @@ jobs:
         run: |
           sudo debconf-communicate <<< "set man-db/auto-update false" || true
           sudo dpkg-reconfigure man-db || true
-          sudo chown $USER /mnt
-          nix-shell --run "TMP_KIND=/mnt/kind/rawfile/ .ci/deployer.sh start"
+          nix-shell --run ".ci/deployer.sh start"
       - name: Install HelmChart
         env:
           CI_REGISTRY: "${{ inputs.registry }}"
@@ -152,9 +143,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - run: |
-          lsblk
-          df -h
       - uses: DeterminateSystems/nix-installer-action@v17
         with:
           kvm: true
@@ -172,15 +160,11 @@ jobs:
       - name: Build test images
         if: ${{ !inputs.release }}
         run: nix-shell --run "CI_TEST=true .ci/build.sh"
-      - run: |
-          lsblk
-          df -h
       - name: BootStrap k8s cluster
         run: |
           sudo debconf-communicate <<< "set man-db/auto-update false" || true
           sudo dpkg-reconfigure man-db || true
-          sudo chown $USER /mnt
-          nix-shell --run "TMP_KIND=/mnt/kind/rawfile/ .ci/deployer.sh start"
+          nix-shell --run ".ci/deployer.sh start"
       - name: Release Sanity Check
         if: ${{ inputs.release }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ dmypy.json
 .ci/e2e-test/e2e.test
 .ci/e2e-test/ginkgo
 .ci/e2e-test/ssh_id
+.ci/kind
 
 /deploy/helm/rawfile-localpv/Chart.lock
 


### PR DESCRIPTION
Sometimes /mnt (sdb1) is 100% used, which is failing the tests since we use /mnt for the test data.
Looks like GitHub docs seems to report only 14GiB of usable data, so I guess we can't rely on this sdb1.