### PR TITLE
ci(gha): add more debug info

### DIFF
--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -26,6 +26,7 @@ on:
 
 env:
   CI: 1
+  TMP_KIND: /mnt/kind/rawfile
 
 jobs:
   smoke:
@@ -35,12 +36,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - run: |
-          lsblk
-          df -h
       - uses: DeterminateSystems/nix-installer-action@v17
         with:
           kvm: true
+      - run: sudo chown $USER /mnt
+      - run: |
+          lsblk
+          df -h
+          sudo du -ah -d 6 --apparent-size /mnt | sort -hr
       - name: Setup Nix Path
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
@@ -49,15 +52,11 @@ jobs:
         run: nix-shell --run "echo"
       - name: Build test images
         run: nix-shell --run "CI_TEST=true .ci/build.sh"
-      - run: |
-          lsblk
-          df -h
       - name: BootStrap k8s cluster
         run: |
           sudo debconf-communicate <<< "set man-db/auto-update false" || true
           sudo dpkg-reconfigure man-db || true
-          sudo chown $USER /mnt
-          nix-shell --run "TMP_KIND=/mnt/kind/rawfile/ .ci/deployer.sh start"
+          nix-shell --run ".ci/deployer.sh start"
       - name: Run K8s tests
         run: nix-shell --run ".ci/smoke.sh"
       - run: |
@@ -81,6 +80,7 @@ jobs:
         run: |
           lsblk
           df -h
+          sudo du -ah -d 6 --apparent-size /mnt | sort -hr
           nix-shell --run "kind export logs ./dump/kind --name rawfile"
           nix-shell --run "kubectl cluster-info dump --output-directory=./dump/k8s --namespaces=openebs,kube-system"
       - name: Upload cluster dump
@@ -100,6 +100,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v17
         with:
           kvm: true
+      - run: sudo chown $USER /mnt
       - name: Setup Nix Path
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
@@ -115,8 +116,7 @@ jobs:
         run: |
           sudo debconf-communicate <<< "set man-db/auto-update false" || true
           sudo dpkg-reconfigure man-db || true
-          sudo chown $USER /mnt
-          nix-shell --run "TMP_KIND=/mnt/kind/rawfile/ .ci/deployer.sh start"
+          nix-shell --run ".ci/deployer.sh start"
       - name: Install HelmChart
         env:
           CI_REGISTRY: "${{ inputs.registry }}"
@@ -152,12 +152,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - run: |
-          lsblk
-          df -h
       - uses: DeterminateSystems/nix-installer-action@v17
         with:
           kvm: true
+      - run: sudo chown $USER /mnt
+      - run: |
+          lsblk
+          df -h
+          sudo du -ah -d 6 --apparent-size /mnt | sort -hr
       - name: Setup Nix Path
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
@@ -172,15 +174,11 @@ jobs:
       - name: Build test images
         if: ${{ !inputs.release }}
         run: nix-shell --run "CI_TEST=true .ci/build.sh"
-      - run: |
-          lsblk
-          df -h
       - name: BootStrap k8s cluster
         run: |
           sudo debconf-communicate <<< "set man-db/auto-update false" || true
           sudo dpkg-reconfigure man-db || true
-          sudo chown $USER /mnt
-          nix-shell --run "TMP_KIND=/mnt/kind/rawfile/ .ci/deployer.sh start"
+          nix-shell --run ".ci/deployer.sh start"
       - name: Release Sanity Check
         if: ${{ inputs.release }}
         run: |
@@ -209,6 +207,7 @@ jobs:
         run: |
           lsblk
           df -h
+          sudo du -ah -d 6 --apparent-size /mnt | sort -hr
           nix-shell --run "kind export logs ./dump/kind --name rawfile"
           nix-shell --run "kubectl cluster-info dump --output-directory=./dump/k8s --namespaces=openebs,kube-system"
       - name: Upload cluster dump

--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ dmypy.json
 .ci/e2e-test/e2e.test
 .ci/e2e-test/ginkgo
 .ci/e2e-test/ssh_id
+.ci/kind
 
 /deploy/helm/rawfile-localpv/Chart.lock
 


### PR DESCRIPTION
Sometimes /mnt (sdb1) is 100% used, which is failing the tests since we use /mnt for the test data.
Add more debugging information on /mnt.