### PR TITLE
feat(lock): serialize volume operations

### DIFF
--- a/rawfile/bd2fs.py
+++ b/rawfile/bd2fs.py
@@ -23,6 +23,7 @@ from filesystem.utils import get_device_for_mountpoint
 from rawfile_servicer import check_access_type, get_access_type
 from utils.rawfile import img_file, attach_loop, AccessType, path_stats
 from filesystem.base import UnknownFileSystemError
+from utils.lock import VolLock
 
 
 class Bd2FsIdentityServicer(csi_pb2_grpc.IdentityServicer):
@@ -52,25 +53,27 @@ class Bd2FsNodeServicer(csi_pb2_grpc.NodeServicer):
 
     @log_grpc_request
     def NodePublishVolume(self, request, context):
-        staging_dev = f"{request.staging_target_path}/device"
+        with VolLock(request.volume_id):
+            staging_dev = f"{request.staging_target_path}/device"
 
-        path = Path(request.target_path)
-        access_type_actions = {
-            AccessType.mount: path.mkdir,
-            AccessType.block: path.touch,
-        }
-        access_type_actions[get_access_type(request)](exist_ok=True)
-        mount(
-            device=staging_dev,
-            mountpoint=request.target_path,
-            readonly=request.readonly,
-        )
-        return csi_pb2.NodePublishVolumeResponse()
+            path = Path(request.target_path)
+            access_type_actions = {
+                AccessType.mount: path.mkdir,
+                AccessType.block: path.touch,
+            }
+            access_type_actions[get_access_type(request)](exist_ok=True)
+            mount(
+                device=staging_dev,
+                mountpoint=request.target_path,
+                readonly=request.readonly,
+            )
+            return csi_pb2.NodePublishVolumeResponse()
 
     @log_grpc_request
     def NodeUnpublishVolume(self, request, context):
-        unmount(request.target_path, clear_mountpoint=True)
-        return csi_pb2.NodeUnpublishVolumeResponse()
+        with VolLock(request.volume_id):
+            unmount(request.target_path, clear_mountpoint=True)
+            return csi_pb2.NodeUnpublishVolumeResponse()
 
     @log_grpc_request
     def NodeGetInfo(self, request, context):
@@ -78,55 +81,63 @@ class Bd2FsNodeServicer(csi_pb2_grpc.NodeServicer):
 
     @log_grpc_request
     def NodeStageVolume(self, request, context):
-        bd_stage_request = NodeStageVolumeRequest()
-        bd_stage_request.CopyFrom(request)
-        block_path = f"{request.staging_target_path}/block"
-        device_path = f"{request.staging_target_path}/device"
-        bd_stage_request.staging_target_path = block_path
-        Path(bd_stage_request.staging_target_path).mkdir(exist_ok=True, parents=True)
-        self.bds.NodeStageVolume(bd_stage_request, context)
+        with VolLock(request.volume_id):
+            bd_stage_request = NodeStageVolumeRequest()
+            bd_stage_request.CopyFrom(request)
+            block_path = f"{request.staging_target_path}/block"
+            device_path = f"{request.staging_target_path}/device"
+            bd_stage_request.staging_target_path = block_path
+            Path(bd_stage_request.staging_target_path).mkdir(
+                exist_ok=True, parents=True
+            )
+            self.bds.NodeStageVolume(bd_stage_request, context)
 
-        bd_publish_request = NodePublishVolumeRequest()
-        bd_publish_request.volume_id = request.volume_id
-        bd_publish_request.publish_context.update(request.publish_context)
-        bd_publish_request.staging_target_path = bd_stage_request.staging_target_path
-        bd_publish_request.target_path = device_path
-        bd_publish_request.volume_capability.CopyFrom(request.volume_capability)
-        bd_publish_request.readonly = False
-        bd_publish_request.secrets.update(request.secrets)
-        bd_publish_request.volume_context.update(request.volume_context)
+            bd_publish_request = NodePublishVolumeRequest()
+            bd_publish_request.volume_id = request.volume_id
+            bd_publish_request.publish_context.update(request.publish_context)
+            bd_publish_request.staging_target_path = (
+                bd_stage_request.staging_target_path
+            )
+            bd_publish_request.target_path = device_path
+            bd_publish_request.volume_capability.CopyFrom(request.volume_capability)
+            bd_publish_request.readonly = False
+            bd_publish_request.secrets.update(request.secrets)
+            bd_publish_request.volume_context.update(request.volume_context)
 
-        self.bds.NodePublishVolume(bd_publish_request, context)
+            self.bds.NodePublishVolume(bd_publish_request, context)
 
-        if get_access_type(request) is AccessType.mount:
-            default_fs = request.volume_capability.mount.fs_type
-            fs = get_from_device_or_fallback(bd_publish_request.target_path, default_fs)
-            fs.mountpoint = f"{request.staging_target_path}/mount"
-            fs.format_and_mount(
-                mount_options=[]
-            )  # TODO: Respect from bd_publish_request.volume_capability
+            if get_access_type(request) is AccessType.mount:
+                default_fs = request.volume_capability.mount.fs_type
+                fs = get_from_device_or_fallback(
+                    bd_publish_request.target_path, default_fs
+                )
+                fs.mountpoint = f"{request.staging_target_path}/mount"
+                fs.format_and_mount(
+                    mount_options=[]
+                )  # TODO: Respect from bd_publish_request.volume_capability
 
-        return csi_pb2.NodeStageVolumeResponse()
+            return csi_pb2.NodeStageVolumeResponse()
 
     @log_grpc_request
     def NodeUnstageVolume(self, request, context):
-        mount_path = f"{request.staging_target_path}/mount"
-        device_path = f"{request.staging_target_path}/device"
-        unmount(mount_path, clear_mountpoint=True)
+        with VolLock(request.volume_id):
+            mount_path = f"{request.staging_target_path}/mount"
+            device_path = f"{request.staging_target_path}/device"
+            unmount(mount_path, clear_mountpoint=True)
 
-        bd_unpublish_request = NodeUnpublishVolumeRequest()
-        bd_unpublish_request.volume_id = request.volume_id
-        bd_unpublish_request.target_path = device_path
-        self.bds.NodeUnpublishVolume(bd_unpublish_request, context)
+            bd_unpublish_request = NodeUnpublishVolumeRequest()
+            bd_unpublish_request.volume_id = request.volume_id
+            bd_unpublish_request.target_path = device_path
+            self.bds.NodeUnpublishVolume(bd_unpublish_request, context)
 
-        bd_unstage_request = NodeUnstageVolumeRequest()
-        bd_unstage_request.CopyFrom(request)
-        block_path = f"{request.staging_target_path}/block"
-        bd_unstage_request.staging_target_path = block_path
-        self.bds.NodeUnstageVolume(bd_unstage_request, context)
-        be_absent(bd_unstage_request.staging_target_path)
+            bd_unstage_request = NodeUnstageVolumeRequest()
+            bd_unstage_request.CopyFrom(request)
+            block_path = f"{request.staging_target_path}/block"
+            bd_unstage_request.staging_target_path = block_path
+            self.bds.NodeUnstageVolume(bd_unstage_request, context)
+            be_absent(bd_unstage_request.staging_target_path)
 
-        return csi_pb2.NodeUnstageVolumeResponse()
+            return csi_pb2.NodeUnstageVolumeResponse()
 
     # @log_grpc_request
     def NodeGetVolumeStats(self, request, context):
@@ -153,44 +164,45 @@ class Bd2FsNodeServicer(csi_pb2_grpc.NodeServicer):
 
     @log_grpc_request
     def NodeExpandVolume(self, request, context):
-        if get_access_type(request) is AccessType.block:
-            device_path = f"{request.staging_target_path}/device"
-            request.volume_path = device_path
-            self.bds.NodeExpandVolume(request, context)
+        with VolLock(request.volume_id):
+            if get_access_type(request) is AccessType.block:
+                device_path = f"{request.staging_target_path}/device"
+                request.volume_path = device_path
+                self.bds.NodeExpandVolume(request, context)
+                size = request.capacity_range.required_bytes
+                return csi_pb2.NodeExpandVolumeResponse(capacity_bytes=size)
+
+            # FIXME: hacky way to determine if `volume_path` is staged path,
+            # or the mount itself
+            # Based on CSI 1.4.0 specifications:
+            # > The staging_target_path field is not required,
+            # for backwards compatibility,
+            # but the CO SHOULD supply it.
+            # Apparently, k8s 1.18 does not supply it. So:
+            dev_path = get_device_for_mountpoint(request.volume_path)
+            volume_path = request.volume_path
+            if dev_path is None:
+                dev_path = f"{request.volume_path}/device"
+                volume_path = f"{request.volume_path}/mount"
+
+            bd_request = NodeExpandVolumeRequest()
+            bd_request.CopyFrom(request)
+            bd_request.volume_path = dev_path
+            self.bds.NodeExpandVolume(bd_request, context)
+
+            # Based on CSI 1.4.0 specifications:
+            # > If volume_capability is omitted the SP MAY determine
+            # > access_type from given volume_path for the volume and perform
+            # > node expansion.
+            # Apparently k8s 1.18 omits this field.
+            fs = from_device(dev_path)
+            if not fs:
+                raise UnknownFileSystemError(device=dev_path)
+            fs.mountpoint = volume_path
+            fs.resize()
+
             size = request.capacity_range.required_bytes
             return csi_pb2.NodeExpandVolumeResponse(capacity_bytes=size)
-
-        # FIXME: hacky way to determine if `volume_path` is staged path,
-        # or the mount itself
-        # Based on CSI 1.4.0 specifications:
-        # > The staging_target_path field is not required,
-        # for backwards compatibility,
-        # but the CO SHOULD supply it.
-        # Apparently, k8s 1.18 does not supply it. So:
-        dev_path = get_device_for_mountpoint(request.volume_path)
-        volume_path = request.volume_path
-        if dev_path is None:
-            dev_path = f"{request.volume_path}/device"
-            volume_path = f"{request.volume_path}/mount"
-
-        bd_request = NodeExpandVolumeRequest()
-        bd_request.CopyFrom(request)
-        bd_request.volume_path = dev_path
-        self.bds.NodeExpandVolume(bd_request, context)
-
-        # Based on CSI 1.4.0 specifications:
-        # > If volume_capability is omitted the SP MAY determine
-        # > access_type from given volume_path for the volume and perform
-        # > node expansion.
-        # Apparently k8s 1.18 omits this field.
-        fs = from_device(dev_path)
-        if not fs:
-            raise UnknownFileSystemError(device=dev_path)
-        fs.mountpoint = volume_path
-        fs.resize()
-
-        size = request.capacity_range.required_bytes
-        return csi_pb2.NodeExpandVolumeResponse(capacity_bytes=size)
 
 
 class Bd2FsControllerServicer(csi_pb2_grpc.ControllerServicer):
@@ -237,7 +249,13 @@ class Bd2FsControllerServicer(csi_pb2_grpc.ControllerServicer):
 
     @log_grpc_request
     def DeleteVolume(self, request, context):
-        return self.bds.DeleteVolume(request, context)
+        try:
+            lock = VolLock(request.volume_id)
+        except FileNotFoundError:
+            return csi_pb2.DeleteVolumeResponse()
+        else:
+            with lock:
+                return self.bds.DeleteVolume(request, context)
 
     def GetCapacity(self, request, context):
         return self.bds.GetCapacity(request, context)
@@ -286,6 +304,7 @@ class Bd2FsControllerServicer(csi_pb2_grpc.ControllerServicer):
         loop_dev = None
         snapshot_id = request.snapshot_id
         volume_id, name = snapshot_id.rsplit("/", 1)
+
         try:
             file = img_file(volume_id)
             loop_dev = attach_loop(file)

--- a/rawfile/orchestrator/k8s.py
+++ b/rawfile/orchestrator/k8s.py
@@ -84,7 +84,8 @@ def run_on_node(fn, node):
         exit_code = task_pod.obj["status"]["containerStatuses"][0]["state"][
             "terminated"
         ]["exitCode"]
-        raise CalledProcessError(returncode=exit_code, cmd=f"Task: {name}")
+        logger.error("run_on_node task failed", exit_code=exit_code, output=logs)
+        raise CalledProcessError(returncode=exit_code, cmd=f"Task: {name}", output=logs)
 
     match = re.search(f"{VOLUME_IS_ATTACHED}=(True|False)", logs)
     is_attached = match.group(1) == "True" if match else None

--- a/rawfile/utils/lock.py
+++ b/rawfile/utils/lock.py
@@ -1,0 +1,26 @@
+import fcntl
+from utils.rawfile import lock_file
+
+"""
+  This can be used to ensure there's only 1 operation running at a time for a given volume.
+"""
+
+
+class VolLock:
+    def __init__(self, volume_id):
+        self.path = lock_file(volume_id)
+        self.path.touch(exist_ok=True)
+        self.file = open(self.path, "a")
+
+    def __enter__(self):
+        # grabs the lock or fails right away
+        fcntl.flock(self.file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return self
+
+    def release(self):
+        if hasattr(self, "file"):
+            fcntl.flock(self.file, fcntl.LOCK_UN)
+            self.file.close()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.release()

--- a/rawfile/utils/rawfile.py
+++ b/rawfile/utils/rawfile.py
@@ -99,6 +99,10 @@ def meta_file(volume_id):
     return Path(f"{img_dir(volume_id)}/disk.meta")
 
 
+def lock_file(volume_id):
+    return Path(f"{img_dir(volume_id)}/disk.lock")
+
+
 def metadata(volume_id):
     return json.loads(meta_file(volume_id).read_text())
 
@@ -119,6 +123,7 @@ def destroy(volume_id, dry_run=True):
     if not dry_run:
         Path(img_file(volume_id)).unlink(missing_ok=True)
         Path(meta_file(volume_id)).unlink(missing_ok=True)
+        Path(lock_file(volume_id)).unlink(missing_ok=True)
         try:
             Path(img_dir(volume_id)).rmdir()
         except FileNotFoundError:

--- a/rawfile/utils/remote.py
+++ b/rawfile/utils/remote.py
@@ -3,6 +3,7 @@ import base64
 import pickle
 
 from consts import D_PERMS
+from utils.lock import VolLock
 
 
 class remote_fn(object):
@@ -71,20 +72,21 @@ def init_rawfile(volume_id, size):
     img_dir = utils.rawfile.img_dir(volume_id)
     img_dir.mkdir(mode=D_PERMS, exist_ok=True)
 
-    img_file = Path(f"{img_dir}/disk.img")
-    if img_file.exists():
-        return
-    utils.rawfile.patch_metadata(
-        volume_id,
-        {
-            "schema_version": LATEST_SCHEMA_VERSION,
-            "volume_id": volume_id,
-            "created_at": time.time(),
-            "img_file": img_file.as_posix(),
-            "size": size,
-        },
-    )
-    utils.rawfile.truncate(img_file, size)
+    with VolLock(volume_id):
+        img_file = Path(f"{img_dir}/disk.img")
+        if img_file.exists():
+            return
+        utils.rawfile.patch_metadata(
+            volume_id,
+            {
+                "schema_version": LATEST_SCHEMA_VERSION,
+                "volume_id": volume_id,
+                "created_at": time.time(),
+                "img_file": img_file.as_posix(),
+                "size": size,
+            },
+        )
+        utils.rawfile.truncate(img_file, size)
 
 
 def get_capacity():
@@ -126,20 +128,22 @@ def log_attached(volume_id):
 def expand_rawfile(volume_id, size):
     import utils.rawfile
     from utils.remote import log_attached
+    from utils.lock import VolLock
     from consts import RESOURCE_EXHAUSTED_EXIT_CODE
 
-    img_file = utils.rawfile.img_file(volume_id)
-    size_inc = size - utils.rawfile.metadata(volume_id)["size"]
-    if size_inc <= 0:
+    with VolLock(volume_id):
+        img_file = utils.rawfile.img_file(volume_id)
+        size_inc = size - utils.rawfile.metadata(volume_id)["size"]
+        if size_inc <= 0:
+            log_attached(volume_id)
+            return
+
+        if utils.rawfile.get_capacity() < size_inc:
+            exit(RESOURCE_EXHAUSTED_EXIT_CODE)
+
+        utils.rawfile.truncate(img_file, size)
+        utils.rawfile.patch_metadata(
+            volume_id,
+            {"size": size},
+        )
         log_attached(volume_id)
-        return
-
-    if utils.rawfile.get_capacity() < size_inc:
-        exit(RESOURCE_EXHAUSTED_EXIT_CODE)
-
-    utils.rawfile.truncate(img_file, size)
-    utils.rawfile.patch_metadata(
-        volume_id,
-        {"size": size},
-    )
-    log_attached(volume_id)


### PR DESCRIPTION
Ensures there's only 1 volume operation at a time. In case CSI times out, it may retry an operation, and thus we should ensure that there's no more than 1 at a time.
Also will help ensure the snapshot can safely determine when to remove a loop device.