### PR TITLE
Fix ServiceMonitor Interval in Helm Chart

### DIFF
--- a/deploy/helm/rawfile-localpv/templates/node-plugin/servicemonitor.yaml
+++ b/deploy/helm/rawfile-localpv/templates/node-plugin/servicemonitor.yaml
@@ -10,7 +10,9 @@ spec:
   endpoints:
   - port: metrics
     path: /metrics
-    interval: {{ .Values.serviceMonitor.interval }}
+    {{- with .Values.metrics.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
   jobLabel: "helm.sh/chart"
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
Hi, I'm just trying out this project and during installation I discovered a bug in the Helm chart: When `metrics.serviceMonitor.enabled` is `true`, the chart fails to render, because it tries to use `serviceMonitor.interval` instead of `metrics.serviceMonitor.interval`. See this by running:

```shell
helm template deploy/helm/rawfile-localpv --set metrics.serviceMonitor.enabled=true
```

This PR fixes the problem by using `metrics.serviceMonitor.interval` (as is given in `values.yaml`). It also adds support for omitting the interval entirely.