### PR TITLE
:arrow_down: Downgrade debian from `trixie` to `bookworm`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-trixie AS base
+FROM python:3.13-slim-bookworm AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
This is due to our problem with ARM builds after upgrading debian version