### PR TITLE
Fix reserving capacity logic

### DIFF
--- a/deploy/helm/rawfile-localpv/README.md
+++ b/deploy/helm/rawfile-localpv/README.md
@@ -31,7 +31,6 @@ Please follow the [install guide](https://github.com/openebs/rawfile-localpv/tre
 | auth.token | string | `""` | Sets authentication token for internal gRPC server, will generate one if nothing provided |
 | capabilities.resize.enabled | bool | `true` | Sets whether volume resizing is enabled. If disabled, don't deploy controller statefulset |
 | capabilities.snapshots.enabled | bool | `true` | Sets whether taking volume snapshots is enabled. Required for volume cloning. Runs externalSnapshotter and snapshotController containers. |
-| capacityOverride | string | `""` | Overrides total capacity of the storage for data dir storage on each host (Support size values) [e.g. `50GB` or `10MiB`] (Deprecated, use storagePools.capacityOverride instead) |
 | controller.affinity | string | `nil` | Affinities for controller component |
 | controller.externalResizer.image.registry | string | `""` | Image registry for `csi-resizer` |
 | controller.externalResizer.image.repository | string | `"sig-storage/csi-resizer"` | Image Repository for `csi-resizer` |
@@ -64,7 +63,7 @@ Please follow the [install guide](https://github.com/openebs/rawfile-localpv/tre
 | metrics.serviceMonitor.enabled | bool | `false` | Enables prometheus service monitor |
 | metrics.serviceMonitor.interval | string | `"1m"` | Sets prometheus target interval |
 | node.affinity | string | `nil` | Affinities for node component |
-| node.dataDirPath | string | `"/var/csi/rawfile"` | Path to store data dir (Depricated, use storagePools.path instead) |
+| node.dataDirPath | string | `"/var/csi/rawfile"` | Path to store data dir (Deprecated, use storagePools.path instead) |
 | node.defaultFs | string | `"ext4"` | Default filesystem type for rawfile volumes (Currently supports `btrfs`, `xfs` and `ext4` [which is default]) |
 | node.driverRegistrar.healthzPort | int | `9809` | Healthcheck port for driver-registrar |
 | node.driverRegistrar.image.registry | string | `""` | Image Registry for `csi-node-driver-registrar` |

--- a/deploy/helm/rawfile-localpv/templates/controller/statefulset.yaml
+++ b/deploy/helm/rawfile-localpv/templates/controller/statefulset.yaml
@@ -54,10 +54,6 @@ spec:
             - name: RESERVED_CAPACITY
               value: {{ .Values.reservedCapacity | toString | quote }}
             {{- end }}
-            {{- if .Values.capacityOverride }}
-            - name: CAPACITY_OVERRIDE
-              value: {{ .Values.capacityOverride | toString | quote }}
-            {{- end }}
             - name: CSI_DRIVER__GRPC_WORKERS
               value: {{ .Values.controller.grpcWorkers | toString | quote }}
             - name: GA_ENABLED

--- a/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
+++ b/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
@@ -81,10 +81,6 @@ spec:
             - name: RESERVED_CAPACITY
               value: {{ .Values.reservedCapacity | toString | quote }}
             {{- end }}
-            {{- if .Values.capacityOverride }}
-            - name: CAPACITY_OVERRIDE
-              value: {{ .Values.capacityOverride | toString | quote }}
-            {{- end }}
             - name: CSI_DRIVER__GRPC_WORKERS
               value: {{ .Values.node.grpcWorkers | toString | quote }}
             - name: GA_ENABLED
@@ -136,9 +132,6 @@ spec:
                     {{- with .Values.reservedCapacity }}
                     , "reserved_capacity": "{{ . | toString }}"
                     {{- end }}
-                    {{- with .Values.capacityOverride }}
-                    , "capacity_override": "{{ . | toString }}"
-                    {{- end }}
                     }
                   {{- else }}
                   {{- $keys := keys .Values.node.storagePools | sortAlpha }}
@@ -148,8 +141,13 @@ spec:
                     {{- with (index $.Values.node.storagePools $name).reservedCapacity }}
                     , "reserved_capacity": "{{ . | toString }}"
                     {{- end }}
-                    {{- with (index $.Values.node.storagePools $name).capacityOverride }}
-                    , "capacity_override": "{{ . | toString }}"
+                    {{- with (index $.Values.node.storagePools $name).reservedCapacityMode }}
+                    , "reserved_capacity_mode": "{{ . | toString }}"
+                    {{- end }}
+                    {{- with (index $.Values.node.storagePools $name) }}
+                    {{- if hasKey . "accountVolumesFreeSpace" }}
+                    , "account_volumes_free_space": {{ .accountVolumesFreeSpace }}
+                    {{- end }}
                     {{- end }}
                   }{{ if lt (add1 $i) (len $keys) }},{{ end }}
                   {{- end }}

--- a/deploy/helm/rawfile-localpv/values.yaml
+++ b/deploy/helm/rawfile-localpv/values.yaml
@@ -8,8 +8,6 @@ logFormat: json
 
 # -- Used to reserve capacity on each node for data dir storage on each host (Supports percentage and size) [e.g. `25%` or `50GB` or `10MiB`] (Deprecated, use storagePools.reservedCapacity instead)
 reservedCapacity: ""
-# -- Overrides total capacity of the storage for data dir storage on each host (Support size values) [e.g. `50GB` or `10MiB`] (Deprecated, use storagePools.capacityOverride instead)
-capacityOverride: ""
 
 auth:
   # -- Enables authentication for internal gRPC server
@@ -158,7 +156,7 @@ node:
   # -- Default filesystem type for rawfile volumes (Currently supports `btrfs`, `xfs` and `ext4` [which is default])
   defaultFs: ext4
 
-  # -- Path to store data dir (Depricated, use storagePools.path instead)
+  # -- Path to store data dir (Deprecated, use storagePools.path instead)
   dataDirPath: /var/csi/rawfile
 
   # -- Default storage pool name
@@ -167,8 +165,10 @@ node:
   # storagePools:
   #   default:
   #     path: /var/local/openebs/rawfile/default-pool/
+  # -- Reserved capacity outside of the storage pool, can be specified in bytes or percentage of the underlying device capacity
   #     reservedCapacity: ""
-  #     capacityOverride: ""
+  # -- Reserved capacity mode. `Plain` means it's taken as-is, `subtract-from-total` means it's subtracted from underlying device capacity. Example: if reservedCapacity is 100GiB, then `plain` means the pool can grow until 100GiB is left, and `subtract-from-total` means it can grow up to 100GiB. Default: `plain`
+  #     reservedCapacityMode: "plain" | "subtract-from-total"
 
   # -- Metadata dir path for rawfile volumes metadata and tasks store file
   metadataDirPath: /var/local/openebs/rawfile/{{ .Release.Name }}/meta

--- a/rawfile/bd2fs.py
+++ b/rawfile/bd2fs.py
@@ -37,7 +37,7 @@ from rawfile_servicer import check_access_type, get_access_type
 from utils.rawfile import (
     AccessType,
 )
-from utils.devices import path_stats
+from utils.devices import statvfs
 from filesystem.base import UnknownFileSystemError
 from utils.lock import VolLock
 from utils.task_manager import TaskManager
@@ -180,7 +180,7 @@ class Bd2FsNodeServicer(csi_pb2_grpc.NodeServicer):
         volume_path = request.volume_path
         if Path(volume_path).is_block_device():
             return self.bds.NodeGetVolumeStats(request, context)
-        stats = path_stats(volume_path)
+        stats = statvfs(volume_path)
         return csi_pb2.NodeGetVolumeStatsResponse(
             usage=[
                 csi_pb2.VolumeUsage(

--- a/rawfile/config/model.py
+++ b/rawfile/config/model.py
@@ -1,5 +1,12 @@
 import re
 import warnings
+import consts
+import json
+
+from filesystem.types import FileSystemName
+from typing import Annotated, Final, Literal
+from datetime import timedelta
+
 from pydantic_settings import (
     BaseSettings,
     CliSettingsSource,
@@ -7,7 +14,6 @@ from pydantic_settings import (
     PydanticBaseSettingsSource,
     SettingsConfigDict,
 )
-from filesystem.types import FileSystemName
 from pydantic import (
     AliasChoices,
     AnyUrl,
@@ -20,11 +26,9 @@ from pydantic import (
     model_validator,
 )
 from pydantic.networks import IPvAnyAddress
-from typing import Annotated, Final, Literal
-import consts
+
 from utils.logs import LoggingFormats
-from datetime import timedelta
-import json
+from utils.modeltypes import ReservedCapacityMode
 
 NAME_REGEX: Final[re.Pattern] = re.compile(
     r"^(?=.{1,253}$)(?!.*\.\.)([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)(\.([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?))*$"
@@ -51,18 +55,26 @@ class Capabilities(BaseModel):
 class StoragePool(BaseModel):
     path: DirectoryPath = Field(description="Path of the pool, Should be unique")
     reserved_capacity: (
-        ByteSize
-        | Annotated[
+        Annotated[
             str,
             StringConstraints(strip_whitespace=True, pattern=r"^\d+%$"),
         ]
+        | ByteSize
     ) = Field(
         default=ByteSize(0),
-        description="Reserves capacity of storage pool",
+        description="""Reserves some disk capacity for uses other than this driver. May be specified in percentage
+        of total capacity or in bytes with commonly used suffixes""",
+        # since the ByteSize parses '123%', union_mode='left_to_right' and
+        # annotated string coming first in the union matters
+        union_mode="left_to_right",
     )
-    capacity_override: ByteSize | None = Field(
-        default=None,
-        description="Overrides total capacity of storage pool",
+
+    reserved_capacity_mode: ReservedCapacityMode = Field(
+        default=ReservedCapacityMode.PLAIN,
+        description="""Defines reserved mode. `plain` means reserved capacity is set directly as-is;
+        `subtract-from-total` means effective reserved capacity is total capacity minus reserved_capacity.
+        Effectively, `subtract-from-total` is analogous to "reserve for this pool only", while "plain"
+        is "reserve for everything else but this pool".""",
     )
 
 

--- a/rawfile/metrics.py
+++ b/rawfile/metrics.py
@@ -20,6 +20,7 @@ class VolumeStatsCollector(object):
     def __init__(self, node):
         self.node = node
 
+    # TODO (pgu, 09.02.2026): should these metrics be per node per pool?
     def collect(self):
         remaining_capacity = GaugeMetricFamily(
             "rawfile_remaining_capacity",
@@ -42,7 +43,7 @@ class VolumeStatsCollector(object):
         remaining_capacity.add_metric([self.node], get_remaining_capacity())
         for volume_id, stats in volume_manager.get_all_volumes_stats().items():
             volume_used.add_metric([self.node, volume_id], stats["used"])
-            volume_total.add_metric([self.node, volume_id], stats["total"])
+            volume_total.add_metric([self.node, volume_id], stats["logical_size"])
         return [remaining_capacity, volume_used, volume_total]
 
 

--- a/rawfile/rawfile.py
+++ b/rawfile/rawfile.py
@@ -19,6 +19,7 @@ from analytics.ga4 import run_ping, shutdown_event_worker, run_event_worker
 from orchestrator.k8s import node_ip_mapping
 from utils.rawfile import is_cow_supported
 from utils.volume_manager import manager as volume_manager
+from utils.devices import stat
 from setproctitle import setproctitle
 import ipaddress
 import os
@@ -40,12 +41,21 @@ def node_driver_preflight_checks(task_manager: task_manager.TaskManager):
         raise RuntimeError("CSI Driver configuration is missing")
     if not config.csi_driver.metadata_dir:
         raise RuntimeError("Metadata directory is not set for node plugin")
+
     dirs = [
         config.csi_driver.metadata_dir,
     ]
     dirs.extend([pool.path for pool in config.csi_driver.storage_pools.values()])
     for dir in dirs:
         __create_and_check_directory(dir)
+
+    devs = set()
+    for path in [pool.path for pool in config.csi_driver.storage_pools.values()]:
+        dev = stat(path)["dev"]
+        if dev in devs:
+            raise RuntimeError("Multiple pools cannot be backed by the same filesystem")
+        devs.add(dev)
+
     volume_manager.migrate_metadata_dir()
     volume_manager.migrate_all_volume_schemas()
     task_manager.migrate_tasks_file_path()

--- a/rawfile/utils/devices.py
+++ b/rawfile/utils/devices.py
@@ -1,26 +1,40 @@
-from pydantic import ByteSize
-from utils.commands import run
 import os
 import subprocess
 import json
+
 from pathlib import Path
 
+from utils.commands import run
 
-def path_stats(path, capacity_override: ByteSize | None = None):
+
+def statvfs(path):
     fs_stat = os.statvfs(path)
 
     total = fs_stat.f_frsize * fs_stat.f_blocks
-    if capacity_override:
-        total = capacity_override.to("B")
     avail = fs_stat.f_frsize * fs_stat.f_bavail
+    # FIXME (pgu, 09.02.2026): this is not necessarily true in the sense that
+    # f_bavail shows blocks available to non-privileged users; hence usage will
+    # implicitly include all the blocks reserved for priviliged users in the
+    # stats
     usage = total - avail
 
     return {
         "fs_size": total,
-        "fs_avail": total - usage,
+        "fs_avail": avail,
         "fs_usage": usage,
         "fs_files": fs_stat.f_files,
         "fs_files_avail": fs_stat.f_favail,
+        "fs_id": fs_stat.f_fsid,
+    }
+
+
+def stat(filepath):
+    stat = os.stat(filepath)
+
+    return {
+        "logical_size": stat.st_size,
+        "physical_size": stat.st_blocks * 512,
+        "dev": stat.st_dev,
     }
 
 

--- a/rawfile/utils/modeltypes.py
+++ b/rawfile/utils/modeltypes.py
@@ -1,0 +1,6 @@
+from enum import StrEnum
+
+
+class ReservedCapacityMode(StrEnum):
+    PLAIN = "plain"
+    SUBTRACT_FROM_TOTAL = "subtract-from-total"

--- a/rawfile/utils/storage_pool.py
+++ b/rawfile/utils/storage_pool.py
@@ -1,18 +1,71 @@
-from utils.devices import path_stats
-from utils.volume_manager import manager as volume_manager
+from pydantic import ByteSize
+
 from config import config
+from utils.devices import statvfs
+from utils.volume_manager import manager as volume_manager
+from utils.modeltypes import ReservedCapacityMode
+
+from collections.abc import Callable
+
+
+# if the mode is "plain", reserved capacity is taken as specified in config
+def plain_reserved_capacity_handler(
+    disk_total_size: int, reserved_capacity: ByteSize | str
+) -> int:
+    if isinstance(reserved_capacity, str):
+        return disk_total_size * int(reserved_capacity[:-1]) / 100
+    elif isinstance(reserved_capacity, ByteSize):
+        return reserved_capacity.to("B")
+
+
+# if the mode is "subtract-from-total", reserved capacity is taken as (total - specified in config)
+def subtract_from_total_reserved_capacity_handler(
+    disk_total_size: int, reserved_capacity: ByteSize | str
+) -> int:
+    if isinstance(reserved_capacity, str):
+        return disk_total_size - disk_total_size * int(reserved_capacity[:-1]) / 100
+    elif isinstance(reserved_capacity, ByteSize):
+        return disk_total_size - reserved_capacity.to("B")
+
+
+reserved_capacity_handlers: dict[
+    ReservedCapacityMode, Callable[[int, ByteSize | str], int]
+] = {
+    ReservedCapacityMode.PLAIN: plain_reserved_capacity_handler,
+    ReservedCapacityMode.SUBTRACT_FROM_TOTAL: subtract_from_total_reserved_capacity_handler,
+}
 
 
 def get_capacity(storage_pool: str | None = None):
     if not storage_pool:
         storage_pool = config.csi_driver.default_pool
     pool = config.csi_driver.storage_pools[storage_pool]
-    disk_free_size = path_stats(pool.path, pool.capacity_override)["fs_avail"]
-    capacity = disk_free_size
-    for volume_stat in volume_manager.get_all_volumes_stats().values():
-        capacity -= volume_stat["total"] - volume_stat["used"]
-    if isinstance(pool.reserved_capacity, str):
-        capacity -= capacity * int(pool.reserved_capacity[:-1]) / 100
-    else:
-        capacity -= pool.reserved_capacity.to("B")
-    return max(capacity, 0)
+    stats = statvfs(pool.path)
+    disk_total_size = stats["fs_size"]
+    disk_free_size = stats["fs_avail"]
+    reserved_capacity_config = pool.reserved_capacity
+    reserved_capacity_mode = pool.reserved_capacity_mode
+
+    # reserved_capacity is the capacity reserved for everything else but this pool
+    # so the capacity reserved for this pool is (disk_total_size - reserved_capacity)
+    reserved_capacity = reserved_capacity_handlers[reserved_capacity_mode](
+        disk_total_size, reserved_capacity_config
+    )
+
+    volumes_physical_size = 0
+
+    volume_stats_values = volume_manager.get_volumes_stats_by_pool(
+        storage_pool
+    ).values()
+    for volume_stat in volume_stats_values:
+        # if the backing file is sparse, count only the defacto allocated blocks
+        # if not, count the whole thing
+        volumes_physical_size += volume_stat["physical_size"]
+
+    capacity = max(
+        min(
+            disk_total_size - reserved_capacity - volumes_physical_size, disk_free_size
+        ),
+        0,
+    )
+    return capacity

--- a/rawfile/utils/volume_manager.py
+++ b/rawfile/utils/volume_manager.py
@@ -2,7 +2,7 @@ from enum import Enum
 import time
 from typing import TypedDict
 import consts
-from utils.devices import device_to_mountpoint, path_stats
+from utils.devices import device_to_mountpoint, statvfs, stat
 from utils.errors import SourceTypeRequired, VolumeInUseError, VolumeSourceIsNotReady
 from utils.lock import VolLock
 from config import config
@@ -34,8 +34,12 @@ class VolumeSource(int, Enum):
 
 
 class VolumeStats(TypedDict):
-    total: int
+    physical_size: int
+    logical_size: int
     used: int
+    pool: str
+    thin_provision: bool
+    thin: bool
 
 
 class VolumeManager:
@@ -119,6 +123,7 @@ class VolumeManager:
                         "thin_provision": thin_provision,
                         "freezefs": freezefs,
                         "copy_on_write": copy_on_write,
+                        "storage_pool": storage_pool,
                     },
                 )
                 img_file.touch()
@@ -251,6 +256,9 @@ class VolumeManager:
 
     def get_volume_stats(self, volume_id) -> VolumeStats | None:
         try:
+            meta = metadata_or(volume_id)
+            pool = meta.get("storage_pool", config.csi_driver.default_pool)
+            thin_provision = meta.get("thin_provision", False)
             file = img_file(volume_id=volume_id)
             loop_devs = attached_loops(file.as_posix())
             if not (loop_devs and len(loop_devs)):
@@ -258,11 +266,22 @@ class VolumeManager:
             mountpoint = device_to_mountpoint(loop_devs[0])
             if not mountpoint:
                 return None
-            stats = path_stats(mountpoint)
-            return {
-                "used": stats["fs_usage"],
-                "total": stats["fs_size"],
+            filesystem_stats = statvfs(mountpoint)
+            file_stats = stat(file)
+
+            # note that "sparse" here might differ from metadata's
+            # "thin_provision": if the volume was created as thick but formatted
+            # with discarding, it's factually thin i.e. sparse
+            result = {
+                "physical_size": file_stats["physical_size"],
+                "logical_size": file_stats["logical_size"],
+                "used": filesystem_stats["fs_usage"],
+                "pool": pool,
+                "sparse": (file_stats["physical_size"] < file_stats["logical_size"])
+                or thin_provision,
+                "thin_provision": thin_provision,
             }
+            return result
         except (FileNotFoundError, KeyError):
             return None
 
@@ -272,6 +291,14 @@ class VolumeManager:
             volume_stats = self.get_volume_stats(volume_id)
             if volume_stats:
                 stats[volume_id] = self.get_volume_stats(volume_id)
+        return stats
+
+    def get_volumes_stats_by_pool(self, storage_pool: str) -> dict[str, VolumeStats]:
+        stats = {}
+        for volume_id in self.list_all_volumes():
+            volume_stats = self.get_volume_stats(volume_id)
+            if volume_stats and volume_stats["pool"] == storage_pool:
+                stats[volume_id] = volume_stats
         return stats
 
     def migrate_metadata(self, volume_id, target_version):


### PR DESCRIPTION
Summary: fix the reserving capacity logic and make it a little bit more flexible.

Deprecate capacity_override

Enhance reserved_capacity calculations with reserved_capacity_mode

Fix the thin provisioning capacity calculations

Add account_volumes_free_space flag

Modify charts accordingly

Rationale:
Currently, capacity calculations suffer from several problems:

1. capacity_override doesn't do anything; the only place override is used at is `get_capacity()` function, which only cares about device free space calculated directly from `os.statvfs()` call.

2. `get_capacity()` reserves capacity based on the free space left on the device, which is peculiar. It should be based on total capacity instead.

3. `get_capacity()` always assumes thin provisioning, and prevents from overprovisioning. Both the assumptions may be wrong.

New flag, `account_volumes_free_space` fixes point no. 3: if not set, the free space from `os.statvfs()` is the actual free space on disk, which works for thick provisioning and thin provisioning with overprovisioning. If set, it prohibits overprovisioning if volumes are thin-provisioned. This approach is not flawless, as it won't work properly if a single device or storage pool mixes different provisioning type volumes, but fixing that further is out of the scope of this commit.

`get_capacity()` and `path_stats()` changes address points 1 and 2.

`reserved_capacity_mode` allows user to choose whether they want to limit capacity available to CSI driver in top-down or bottom-up manner. For example, if the disk is 1TiB large and `reserved_capacity` is set to 100GiB and the mode is `plain` (default), CSI driver will have access to 1TiB - 100GiB = 900GiB. If the mode is `subtract_from_total`, this is reversed: CSI driver will have access to 1TiB - (1TiB - 100GiB) = 100GiB. This allows to cap CSI driver using absolute numbers while keeping the change backward compatible. Same goes for percentages.

I didn't find proper way to generate chart's README.md though so that's outdated. I would appreciate pointers there.