### PR TITLE
feat: Explicit resources requests/limits for all the containers

### DIFF
--- a/deploy/helm/rawfile-localpv/README.md
+++ b/deploy/helm/rawfile-localpv/README.md
@@ -32,6 +32,7 @@ Please follow the [install guide](https://github.com/openebs/rawfile-localpv/tre
 | controller.externalResizer.image.registry | string | `""` | Image registry for `csi-resizer` |
 | controller.externalResizer.image.repository | string | `"sig-storage/csi-resizer"` | Image Repository for `csi-resizer` |
 | controller.externalResizer.image.tag | string | `"v1.13.2"` | Image tag for `csi-resizer` |
+| controller.externalResizer.resources | object | `{}` | Sets compute resources for external-resizer container |
 | controller.grpcWorkers | int | `10` | Number of gRPC workers for controller component |
 | controller.image.pullPolicy | string | `""` | Overrides default image pull policy for node component |
 | controller.image.repository | string | `""` | Overrides default image repository for node component |
@@ -62,12 +63,15 @@ Please follow the [install guide](https://github.com/openebs/rawfile-localpv/tre
 | node.driverRegistrar.image.registry | string | `""` | Image Registry for `csi-node-driver-registrar` |
 | node.driverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` | Image Repository for `csi-node-driver-registrar` |
 | node.driverRegistrar.image.tag | string | `"v2.13.0"` | Image Tag for `csi-node-driver-registrar` |
+| node.driverRegistrar.resources | object | `{}` | Sets compute resources for driver-registrar container |
 | node.externalProvisioner.image.registry | string | `""` | Image Registry for `csi-provisioner` |
 | node.externalProvisioner.image.repository | string | `"sig-storage/csi-provisioner"` | Image Repository for `csi-provisioner` |
 | node.externalProvisioner.image.tag | string | `"v5.2.0"` | Image Tag for `csi-provisioner` |
+| node.externalProvisioner.resources | object | `{}` | Sets compute resources for external-provisioner container |
 | node.externalSnapshotter.image.registry | string | `""` | Image Registry for `csi-snapshotter` |
 | node.externalSnapshotter.image.repository | string | `"sig-storage/csi-snapshotter"` | Image Repository for `csi-snapshotter` |
 | node.externalSnapshotter.image.tag | string | `"v8.2.1"` | Image Tag for `csi-snapshotter` |
+| node.externalSnapshotter.resources | object | `{}` | Sets compute resources for external-snapshotter container |
 | node.grpcWorkers | int | `10` | Number of gRPC workers for node component |
 | node.image.pullPolicy | string | `""` | Overrides default image pull policy for node component |
 | node.image.repository | string | `""` | Overrides default image repository for node component |
@@ -82,6 +86,7 @@ Please follow the [install guide](https://github.com/openebs/rawfile-localpv/tre
 | node.snapshotController.image.registry | string | `""` | Image Registry for `snapshot-controller` |
 | node.snapshotController.image.repository | string | `"sig-storage/snapshot-controller"` | Image Repository for `snapshot-controller` |
 | node.snapshotController.image.tag | string | `"v8.2.1"` | Image Tag for `snapshot-controller` |
+| node.snapshotController.resources | object | `{}` | Sets compute resources for snapshot-controller container |
 | node.tolerations | string | `nil` | Tolerations for node component |
 | provisionerName | string | `"rawfile.csi.openebs.io"` | Name of the registered CSI Driver in the cluster |
 | reservedCapacity | string | `""` | Used to reserve capacity on each node for data dir storage on each host (Supports percentage and size) [e.g. `25%` or `50GB` or `10MiB`] (Deprecated, use storagePools.reservedCapacity instead) |

--- a/deploy/helm/rawfile-localpv/templates/controller/statefulset.yaml
+++ b/deploy/helm/rawfile-localpv/templates/controller/statefulset.yaml
@@ -97,3 +97,5 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          resources:
+            {{- include "rawfile-localpv.controller-external-resizer-resources" . | nindent 12 }}

--- a/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
+++ b/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
@@ -190,12 +190,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
           resources:
-            limits:
-              cpu: 500m
-              memory: 100Mi
-            requests:
-              cpu: 10m
-              memory: 100Mi
+            {{- include "rawfile-localpv.node-driver-registrar-resources" . | nindent 12 }}
         - name: external-provisioner
           image: {{ printf "%s/%s:%s" (.Values.node.externalProvisioner.image.registry | default .Values.global.k8sImageRegistry) .Values.node.externalProvisioner.image.repository .Values.node.externalProvisioner.image.tag }}
           imagePullPolicy: IfNotPresent
@@ -228,6 +223,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          resources:
+            {{- include "rawfile-localpv.node-external-provisioner-resources" . | nindent 12 }}
         - name: external-snapshotter
           image: {{ printf "%s/%s:%s" (.Values.node.externalSnapshotter.image.registry | default .Values.global.k8sImageRegistry) .Values.node.externalSnapshotter.image.repository .Values.node.externalSnapshotter.image.tag }}
           imagePullPolicy: IfNotPresent
@@ -245,9 +242,13 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          resources:
+            {{- include "rawfile-localpv.node-external-snapshotter-resources" . | nindent 12 }}
         - name: snapshot-controller
           args:
             - "--v=2"
             - "--enable-distributed-snapshotting=true"
+          resources:
+            {{- include "rawfile-localpv.node-snapshot-controller-resources" . | nindent 12 }}
           image: {{ printf "%s/%s:%s" (.Values.node.snapshotController.image.registry | default .Values.global.k8sImageRegistry) .Values.node.snapshotController.image.repository .Values.node.snapshotController.image.tag }}
           imagePullPolicy: IfNotPresent

--- a/deploy/helm/rawfile-localpv/values.yaml
+++ b/deploy/helm/rawfile-localpv/values.yaml
@@ -50,6 +50,9 @@ controller:
     pullPolicy: ""
 
   externalResizer:
+    # -- Sets compute resources for external-resizer container
+    resources:
+      {}
     image:
       # -- Image registry for `csi-resizer`
       registry: ""
@@ -91,6 +94,9 @@ node:
     pullPolicy: ""
 
   driverRegistrar:
+    # -- Sets compute resources for driver-registrar container
+    resources:
+      {}
     image:
       # -- Image Registry for `csi-node-driver-registrar`
       registry: ""
@@ -100,6 +106,9 @@ node:
       tag: v2.13.0
 
   externalProvisioner:
+    # -- Sets compute resources for external-provisioner container
+    resources:
+      {}
     image:
       # -- Image Registry for `csi-provisioner`
       registry: ""
@@ -109,6 +118,9 @@ node:
       tag: v5.2.0
 
   externalSnapshotter:
+    # -- Sets compute resources for external-snapshotter container
+    resources:
+      {}
     image:
       # -- Image Registry for `csi-snapshotter`
       registry: ""
@@ -118,6 +130,9 @@ node:
       tag: v8.2.1
 
   snapshotController:
+    # -- Sets compute resources for snapshot-controller container
+    resources:
+      {}
     image:
       # -- Image Registry for `snapshot-controller`
       registry: ""
@@ -150,12 +165,6 @@ node:
   # -- Sets compute resources for node component
   resources:
     {}
-    # limits:
-    #   cpu: 1
-    #   memory: 100Mi
-    # requests:
-    #   cpu: 10m
-    #   memory: 100Mi
   metrics:
     enabled: false
 


### PR DESCRIPTION
Add `resources` values for all the containers

Rationale: running workloads without setting at least memory limits and cpu requests is either suboptimal or impossible, as production environments are usually keen on knowing every possible resource-related numbers.