### PR TITLE
feat: Optionally disable individual containers

### DIFF
--- a/deploy/helm/rawfile-localpv/README.md
+++ b/deploy/helm/rawfile-localpv/README.md
@@ -29,6 +29,8 @@ Please follow the [install guide](https://github.com/openebs/rawfile-localpv/tre
 | auth.enabled | bool | `true` | Enables authentication for internal gRPC server |
 | auth.secretName | string | `""` | If managing secrets outside the chart, use this to reference the secret name; otherwise, leave empty. |
 | auth.token | string | `""` | Sets authentication token for internal gRPC server, will generate one if nothing provided |
+| capabilities.resize.enabled | bool | `true` | Sets whether volume resizing is enabled. If disabled, don't deploy controller statefulset |
+| capabilities.snapshots.enabled | bool | `true` | Sets whether taking volume snapshots is enabled. Required for volume cloning. Runs externalSnapshotter and snapshotController containers. |
 | capacityOverride | string | `""` | Overrides total capacity of the storage for data dir storage on each host (Support size values) [e.g. `50GB` or `10MiB`] (Deprecated, use storagePools.capacityOverride instead) |
 | controller.affinity | string | `nil` | Affinities for controller component |
 | controller.externalResizer.image.registry | string | `""` | Image registry for `csi-resizer` |

--- a/deploy/helm/rawfile-localpv/templates/controller/statefulset.yaml
+++ b/deploy/helm/rawfile-localpv/templates/controller/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.capabilities.resize.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -84,6 +85,10 @@ spec:
                   {{- end }}
                   key: internal-signature
             {{- end }}
+            - name: CSI_DRIVER__CAPABILITIES__SNAPSHOTS__ENABLED
+              value: "{{ .Values.capabilities.snapshots.enabled }}"
+            - name: CSI_DRIVER__CAPABILITIES__RESIZE__ENABLED
+              value: "{{ .Values.capabilities.resize.enabled }}"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -104,3 +109,4 @@ spec:
               mountPath: /csi
           resources:
             {{- include "rawfile-localpv.controller-external-resizer-resources" . | nindent 12 }}
+{{- end }}

--- a/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
+++ b/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
@@ -155,7 +155,10 @@ spec:
                   {{- end }}
                   {{- end }}
                 }
-
+            - name: CSI_DRIVER__CAPABILITIES__SNAPSHOTS__ENABLED
+              value: "{{ .Values.capabilities.snapshots.enabled }}"
+            - name: CSI_DRIVER__CAPABILITIES__RESIZE__ENABLED
+              value: "{{ .Values.capabilities.resize.enabled }}"
           ports:
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
@@ -234,6 +237,7 @@ spec:
               mountPath: /csi
           resources:
             {{- include "rawfile-localpv.node-external-provisioner-resources" . | nindent 12 }}
+        {{- if .Values.capabilities.snapshots.enabled }}
         - name: external-snapshotter
           image: {{ printf "%s/%s:%s" (.Values.node.externalSnapshotter.image.registry | default .Values.global.k8sImageRegistry) .Values.node.externalSnapshotter.image.repository .Values.node.externalSnapshotter.image.tag }}
           imagePullPolicy: IfNotPresent
@@ -253,6 +257,8 @@ spec:
               mountPath: /csi
           resources:
             {{- include "rawfile-localpv.node-external-snapshotter-resources" . | nindent 12 }}
+        {{- end }}
+        {{- if .Values.capabilities.snapshots.enabled }}
         - name: snapshot-controller
           args:
             - "--v=2"
@@ -261,3 +267,4 @@ spec:
             {{- include "rawfile-localpv.node-snapshot-controller-resources" . | nindent 12 }}
           image: {{ printf "%s/%s:%s" (.Values.node.snapshotController.image.registry | default .Values.global.k8sImageRegistry) .Values.node.snapshotController.image.repository .Values.node.snapshotController.image.tag }}
           imagePullPolicy: IfNotPresent
+        {{- end }}

--- a/deploy/helm/rawfile-localpv/values.yaml
+++ b/deploy/helm/rawfile-localpv/values.yaml
@@ -262,3 +262,11 @@ crds:
     volumeSnapshots:
       # -- Install Volume Snapshot CRDs
       enabled: true
+
+capabilities:
+  snapshots:
+    # -- Sets whether taking volume snapshots is enabled. Required for volume cloning. Runs externalSnapshotter and snapshotController containers.
+    enabled: true
+  resize:
+    # -- Sets whether volume resizing is enabled. If disabled, don't deploy controller statefulset
+    enabled: true

--- a/rawfile/bd2fs.py
+++ b/rawfile/bd2fs.py
@@ -290,11 +290,23 @@ class Bd2FsControllerServicer(csi_pb2_grpc.ControllerServicer):
 
     @log_grpc_request
     def ControllerExpandVolume(self, request, context):
+        if not config.csi_driver.capabilities.resize.enabled:
+            context.abort(
+                grpc.StatusCode.UNIMPLEMENTED,
+                "Resizing capabilities are disabled.",
+            )
+
         response = self.bds.ControllerExpandVolume(request, context)
         return response
 
     @log_grpc_request
     def CreateSnapshot(self, request: csi_pb2.CreateSnapshotRequest, context):
+        if not config.csi_driver.capabilities.snapshots.enabled:
+            context.abort(
+                grpc.StatusCode.UNIMPLEMENTED,
+                "Snapshotting capabilities are disabled.",
+            )
+
         with VolLock(request.source_volume_id):
             volume_meta = metadata(request.source_volume_id)
             freezefs = volume_meta.get("freezefs", False)
@@ -359,6 +371,11 @@ class Bd2FsControllerServicer(csi_pb2_grpc.ControllerServicer):
 
     @log_grpc_request
     def DeleteSnapshot(self, request: csi_pb2.DeleteSnapshotRequest, context):
+        if not config.csi_driver.capabilities.snapshots.enabled:
+            context.abort(
+                grpc.StatusCode.UNIMPLEMENTED,
+                "Snapshotting capabilities are disabled.",
+            )
         snapshot_id = request.snapshot_id
         volume_id, name = snapshot_id.rsplit("/", 1)
         if (
@@ -388,6 +405,11 @@ class Bd2FsControllerServicer(csi_pb2_grpc.ControllerServicer):
 
     @log_grpc_request
     def ListSnapshots(self, request: csi_pb2.ListSnapshotsRequest, context):
+        if not config.csi_driver.capabilities.snapshots.enabled:
+            context.abort(
+                grpc.StatusCode.UNIMPLEMENTED,
+                "Snapshotting capabilities are disabled.",
+            )
         volume_id, name = None, None
         if request.snapshot_id:
             snapshot_id = request.snapshot_id

--- a/rawfile/config/model.py
+++ b/rawfile/config/model.py
@@ -31,6 +31,23 @@ NAME_REGEX: Final[re.Pattern] = re.compile(
 )
 
 
+class BaseCapability(BaseModel):
+    enabled: bool
+
+
+class SnapshotsCapability(BaseCapability):
+    pass
+
+
+class ResizeCapability(BaseCapability):
+    pass
+
+
+class Capabilities(BaseModel):
+    resize: ResizeCapability
+    snapshots: SnapshotsCapability
+
+
 class StoragePool(BaseModel):
     path: DirectoryPath = Field(description="Path of the pool, Should be unique")
     reserved_capacity: (
@@ -108,6 +125,13 @@ class CSIDriverCmd(BaseModel):
     )
     plugin_type: Literal["controller", "node"] = Field(
         description="Type/Mode of the CSI plugin"
+    )
+    capabilities: Capabilities = Field(
+        default=Capabilities(
+            resize=ResizeCapability(enabled=True),
+            snapshots=SnapshotsCapability(enabled=True),
+        ),
+        description="Controls capabilities of the CSI driver",
     )
 
     @field_validator("storage_pools", mode="before")

--- a/rawfile/rawfile_servicer.py
+++ b/rawfile/rawfile_servicer.py
@@ -58,21 +58,22 @@ class RawFileIdentityServicer(csi_pb2_grpc.IdentityServicer):
     @log_grpc_request
     def GetPluginCapabilities(self, request, context):
         Cap = csi_pb2.PluginCapability
-        return csi_pb2.GetPluginCapabilitiesResponse(
-            capabilities=[
-                Cap(service=Cap.Service(type=Cap.Service.CONTROLLER_SERVICE)),
-                Cap(
-                    service=Cap.Service(
-                        type=Cap.Service.VOLUME_ACCESSIBILITY_CONSTRAINTS
+        capabilities = [
+            Cap(service=Cap.Service(type=Cap.Service.CONTROLLER_SERVICE)),
+            Cap(service=Cap.Service(type=Cap.Service.VOLUME_ACCESSIBILITY_CONSTRAINTS)),
+        ]
+        if config.csi_driver.capabilities.resize.enabled:
+            capabilities.extend(
+                [
+                    Cap(
+                        volume_expansion=Cap.VolumeExpansion(
+                            type=Cap.VolumeExpansion.ONLINE
+                        )
                     )
-                ),
-                Cap(
-                    volume_expansion=Cap.VolumeExpansion(
-                        type=Cap.VolumeExpansion.ONLINE
-                    )
-                ),
-            ]
-        )
+                ]
+            )
+
+        return csi_pb2.GetPluginCapabilitiesResponse(capabilities=capabilities)
 
     # @log_grpc_request
     def Probe(self, request, context):
@@ -86,13 +87,17 @@ class RawFileNodeServicer(csi_pb2_grpc.NodeServicer):
     # @log_grpc_request
     def NodeGetCapabilities(self, request, context):
         Cap = csi_pb2.NodeServiceCapability
-        return csi_pb2.NodeGetCapabilitiesResponse(
-            capabilities=[
-                Cap(rpc=Cap.RPC(type=Cap.RPC.STAGE_UNSTAGE_VOLUME)),
-                Cap(rpc=Cap.RPC(type=Cap.RPC.GET_VOLUME_STATS)),
-                Cap(rpc=Cap.RPC(type=Cap.RPC.EXPAND_VOLUME)),
-            ]
-        )
+        capabilities = [
+            Cap(rpc=Cap.RPC(type=Cap.RPC.STAGE_UNSTAGE_VOLUME)),
+            Cap(rpc=Cap.RPC(type=Cap.RPC.GET_VOLUME_STATS)),
+        ]
+        if config.csi_driver.capabilities.resize.enabled:
+            capabilities.extend(
+                [
+                    Cap(rpc=Cap.RPC(type=Cap.RPC.EXPAND_VOLUME)),
+                ]
+            )
+        return csi_pb2.NodeGetCapabilitiesResponse(capabilities=capabilities)
 
     @log_grpc_request
     def NodePublishVolume(self, request, context):
@@ -156,6 +161,12 @@ class RawFileNodeServicer(csi_pb2_grpc.NodeServicer):
 
     @log_grpc_request
     def NodeExpandVolume(self, request, context):
+        if not config.csi_driver.capabilities.resize.enabled:
+            context.abort(
+                grpc.StatusCode.UNIMPLEMENTED,
+                "Resizing capabilities are disabled.",
+            )
+
         volume_path = request.volume_path
         size = request.capacity_range.required_bytes
         volume_path = Path(volume_path).resolve()
@@ -171,16 +182,26 @@ class RawFileControllerServicer(csi_pb2_grpc.ControllerServicer):
     @log_grpc_request
     def ControllerGetCapabilities(self, request, context):
         Cap = csi_pb2.ControllerServiceCapability
-        return csi_pb2.ControllerGetCapabilitiesResponse(
-            capabilities=[
-                Cap(rpc=Cap.RPC(type=Cap.RPC.CREATE_DELETE_VOLUME)),
-                Cap(rpc=Cap.RPC(type=Cap.RPC.GET_CAPACITY)),
-                Cap(rpc=Cap.RPC(type=Cap.RPC.EXPAND_VOLUME)),
-                Cap(rpc=Cap.RPC(type=Cap.RPC.CREATE_DELETE_SNAPSHOT)),
-                Cap(rpc=Cap.RPC(type=Cap.RPC.LIST_SNAPSHOTS)),
-                Cap(rpc=Cap.RPC(type=Cap.RPC.CLONE_VOLUME)),
-            ]
-        )
+        capabilities = [
+            Cap(rpc=Cap.RPC(type=Cap.RPC.CREATE_DELETE_VOLUME)),
+            Cap(rpc=Cap.RPC(type=Cap.RPC.GET_CAPACITY)),
+        ]
+        if config.csi_driver.capabilities.snapshots.enabled:
+            capabilities.extend(
+                [
+                    Cap(rpc=Cap.RPC(type=Cap.RPC.CREATE_DELETE_SNAPSHOT)),
+                    Cap(rpc=Cap.RPC(type=Cap.RPC.LIST_SNAPSHOTS)),
+                    Cap(rpc=Cap.RPC(type=Cap.RPC.CLONE_VOLUME)),
+                ]
+            )
+        if config.csi_driver.capabilities.resize.enabled:
+            capabilities.extend(
+                [
+                    Cap(rpc=Cap.RPC(type=Cap.RPC.EXPAND_VOLUME)),
+                ]
+            )
+
+        return csi_pb2.ControllerGetCapabilitiesResponse(capabilities=capabilities)
 
     @log_grpc_request
     def CreateVolume(self, request: csi_pb2.CreateVolumeRequest, context):
@@ -234,6 +255,15 @@ class RawFileControllerServicer(csi_pb2_grpc.ControllerServicer):
                 source_type = VolumeSource.volume
                 source_id = request.volume_content_source.volume.volume_id
                 required_space = required_space * 3
+
+        if not config.csi_driver.capabilities.snapshots.enabled and (
+            source_type == VolumeSource.volume or source_type == VolumeSource.snapshot
+        ):
+            context.abort(
+                grpc.StatusCode.UNIMPLEMENTED,
+                "Snapshotting capabilities are disabled.",
+            )
+
         if utils.storage_pool.get_capacity() < required_space:
             context.abort(
                 grpc.StatusCode.RESOURCE_EXHAUSTED,
@@ -304,6 +334,12 @@ class RawFileControllerServicer(csi_pb2_grpc.ControllerServicer):
 
     @log_grpc_request
     def ControllerExpandVolume(self, request, context):
+        if not config.csi_driver.capabilities.resize.enabled:
+            context.abort(
+                grpc.StatusCode.UNIMPLEMENTED,
+                "Resizing capabilities are disabled.",
+            )
+
         volume_id = request.volume_id
         node_name = volume_to_node(volume_id)
         size = request.capacity_range.required_bytes


### PR DESCRIPTION
Add `enabled` flag to snapshot-related and resizer containers.

Rationale: if there's no user intention to create VolumeSnapshots or resize volumes, there's no reason to run additional containers.