### PR TITLE
feat: Opt-in for auth secret to be managed outside of the chart

### DIFF
--- a/deploy/helm/rawfile-localpv/README.md
+++ b/deploy/helm/rawfile-localpv/README.md
@@ -27,6 +27,7 @@ Please follow the [install guide](https://github.com/openebs/rawfile-localpv/tre
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | auth.enabled | bool | `true` | Enables authentication for internal gRPC server |
+| auth.secretName | string | `""` | If managing secrets outside the chart, use this to reference the secret name; otherwise, leave empty. |
 | auth.token | string | `""` | Sets authentication token for internal gRPC server, will generate one if nothing provided |
 | capacityOverride | string | `""` | Overrides total capacity of the storage for data dir storage on each host (Support size values) [e.g. `50GB` or `10MiB`] (Deprecated, use storagePools.capacityOverride instead) |
 | controller.externalResizer.image.registry | string | `""` | Image registry for `csi-resizer` |

--- a/deploy/helm/rawfile-localpv/templates/controller/statefulset.yaml
+++ b/deploy/helm/rawfile-localpv/templates/controller/statefulset.yaml
@@ -73,7 +73,11 @@ spec:
             - name: CSI_DRIVER__INTERNAL_SIGNATURE
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.auth.secretName }}
+                  name: {{ .Values.auth.secretName }}
+                  {{- else }}
                   name: {{ include "rawfile-localpv.fullname" . }}-secrets
+                  {{- end }}
                   key: internal-signature
             {{- end }}
           volumeMounts:

--- a/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
+++ b/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
@@ -105,7 +105,11 @@ spec:
             - name: CSI_DRIVER__INTERNAL_SIGNATURE
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.auth.secretName }}
+                  name: {{ .Values.auth.secretName }}
+                  {{- else }}
                   name: {{ include "rawfile-localpv.fullname" . }}-secrets
+                  {{- end }}
                   key: internal-signature
             {{- end }}
             - name: CSI_DRIVER__DEFAULT_FS

--- a/deploy/helm/rawfile-localpv/templates/secret.yaml
+++ b/deploy/helm/rawfile-localpv/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.auth.enabled (not .Values.auth.secretName) }}
 {{- $secret_name := printf "%s-secrets" (include "rawfile-localpv.fullname" .) }}
 apiVersion: v1
 kind: Secret
@@ -17,3 +18,4 @@ data:
   {{- else }}
   internal-signature: {{ .Values.auth.token }}
   {{- end }}
+{{- end }}

--- a/deploy/helm/rawfile-localpv/values.yaml
+++ b/deploy/helm/rawfile-localpv/values.yaml
@@ -16,6 +16,8 @@ auth:
   enabled: true
   # -- Sets authentication token for internal gRPC server, will generate one if nothing provided
   token: ""
+  # -- If managing secrets outside the chart, use this to reference the secret name; otherwise, leave empty.
+  secretName: ""
 
 global:
   # -- Default image registry for Images from DockerHub


### PR DESCRIPTION
Add `auth.secretName` value to reference auth secret managed externally

If it is specified, the chart's secret resource is skipped altogether, and both the controller and node-plugin reference the explicitly named secret instead.

If it is unspecified, the behaviour remains the same as it was.

Rationale: it is a good practice to store secret values in some specialised secret store (Vault comes to mind) as opposed to plaintext chart values. Regenerating it with every Helm chart render is sub-optimal at least from the operations perspective, as it creates diff noise with no real changes behind it.