### PR TITLE
fix: Don't count temporary dir as a snapshot

### DIFF
--- a/rawfile/utils/volume_manager.py
+++ b/rawfile/utils/volume_manager.py
@@ -176,6 +176,8 @@ class VolumeManager:
         if dry_run:
             return
         snapshots = list(snapshots_dir(volume_id).glob("*"))
+        # don't count the temporary dir!
+        snapshots.remove(snapshots_dir(volume_id, temporary=True))
         temp_snapshots = list(snapshots_dir(volume_id, temporary=True).glob("*"))
         total_snapshots = len(snapshots) + len(temp_snapshots)
         meta = metadata_or(volume_id)


### PR DESCRIPTION
When deleting a volume, the snapshots are counted, and due to a logical error, a
temp dir is counted as a snapshot as well. The result is, the volume gets deleted, but
the directories linger, because the driver thinks there are live snapshots. This fixes it.