### PR TITLE
Several improvements on the task manager [tackles flaky CI test]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ pytest.log
 report.xml
 
 rawfile/_fallocate*
+/.vscode

--- a/rawfile/rawfile.py
+++ b/rawfile/rawfile.py
@@ -191,4 +191,6 @@ if __name__ == "__main__":
     if config.gc:
         volume_manager.gc_all_volumes(config.gc.dry_run)
     elif config.csi_driver:
+        if config.csi_driver.plugin_type == "node":
+            volume_manager.gc_all_volumes(True)
         csi_driver(config.csi_driver)

--- a/rawfile/rawfile_servicer.py
+++ b/rawfile/rawfile_servicer.py
@@ -19,7 +19,7 @@ from utils.rawfile import be_absent, be_symlink, metadata, metadata_or
 from google.protobuf.wrappers_pb2 import BoolValue
 from orchestrator.k8s import node_ip_mapping, volume_to_node
 from utils.remote import get_capacity
-from utils.logs import log_grpc_request
+from utils.logs import log_grpc_request, logger
 from utils.commands import run
 from utils.rawfile import (
     AccessType,
@@ -285,6 +285,9 @@ class RawFileControllerServicer(csi_pb2_grpc.ControllerServicer):
                 source_id,
             )
         start_time = time.time()
+        logger.info(
+            "Waiting for volume to be ready", name=request.name, is_ready=is_ready
+        )
         while time.time() - start_time < 30:
             is_ready = metadata_or(request.name).get("ready", False)
             if is_ready:

--- a/rawfile/tests/test_smoke.py
+++ b/rawfile/tests/test_smoke.py
@@ -769,7 +769,8 @@ def _(restore_pvc, restore_pod):
         stdout=True,
         tty=False,
     )
-    logger.error(f"C: {out}")
+    # todo: aren't we missing the check for correct data here!?
+    logger.info(f"cat /{pvc_name}/file => {out}")
 
 
 @when("we delete the snapshot")

--- a/rawfile/utils/commands.py
+++ b/rawfile/utils/commands.py
@@ -4,7 +4,9 @@ from typing import Any
 from datetime import datetime
 
 
-def run(cmd: str, executable: str | None = None, check=True, capture_output=True):
+def run(
+    cmd: str, executable: str | None = None, check=True, capture_output=True, log=True
+):
     start = datetime.now()
     kwargs: dict[str, Any] = {
         "check": check,
@@ -37,5 +39,6 @@ def run(cmd: str, executable: str | None = None, check=True, capture_output=True
                 "stdout": output.stdout.decode(),
             }
         )
-    logger.debug("Shell command execution", **log_ctx)
+    if log:
+        logger.debug("Shell command execution", **log_ctx)
     return output

--- a/rawfile/utils/rawfile.py
+++ b/rawfile/utils/rawfile.py
@@ -140,7 +140,7 @@ def fallocate(img_file, size):
 
 
 def attached_loops(file: str) -> list[str]:
-    out = run(f"losetup -j {file}", capture_output=True).stdout.decode()
+    out = run(f"losetup -j {file}", capture_output=True, log=False).stdout.decode()
     lines = out.splitlines()
     devs = [line.split(":", 1)[0] for line in lines]
     return devs

--- a/rawfile/utils/task_manager.py
+++ b/rawfile/utils/task_manager.py
@@ -72,14 +72,22 @@ class TaskManager:
 
     def retry_worker(self):
         while not self._shutting_down:
-            self.retry_all()
-            for task_id, _ in self.get_tasks(retriable=False).items():
-                self.remove_task(task_id)
-            for task_id, _ in self.get_tasks(state=TaskState.COMPLETED).items():
-                self.remove_task(task_id)
+            try:
+                self.retry_all()
+                for task_id, _ in self.get_tasks(retriable=False).items():
+                    self.remove_task(task_id)
+                for task_id, _ in self.get_tasks(state=TaskState.COMPLETED).items():
+                    self.remove_task(task_id)
+            except Exception as e:
+                # Note that this should not happen unless there's an I/O reading the
+                # task state information or if there's a logic bug in the task management/state storing
+                # since we don't run the tasks directly here
+                logger.error("TaskManager Worker encountered an error", error=e)
             time.sleep(self._retry_interval)
+        logger.info("TaskManager Worker exit after shutdown request...")
 
     def retry_all(self):
+        logger.debug("Retrying all retriable tasks", running=len(self._tasks))
         for task_id, failed_task in self.get_tasks(retriable=True).items():
             logger.debug("Retrying task", task_id=task_id, task=failed_task)
             self.remove_task(task_id)

--- a/rawfile/utils/task_manager.py
+++ b/rawfile/utils/task_manager.py
@@ -172,9 +172,24 @@ class TaskManager:
                 os.fsync(tasks_file.fileno())
 
     def done_callback(self, task_id: str):
+        task_entry = self._tasks.pop(task_id, None)
+        if not task_entry:
+            logger.error(
+                "Task entry missing from the in-memory tasks list", task_id=task_id
+            )
+            return
+
+        task_info: TaskInfo = task_entry.get("info", {})
+        if not task_info:
+            logger.error(
+                "Task information missing from the in-memory task",
+                task_id=task_id,
+                task=task_entry,
+            )
+            return
+
         state: TaskState
-        task_info: TaskInfo = self._tasks.get(task_id, {}).get("info", {})
-        future: Future | None = self._tasks.get(task_id, {}).get("future", None)
+        future: Future | None = task_entry.get("future", None)
         if not (future and (future.exception() or future.cancelled())):
             state = TaskState.COMPLETED
             logger.success("Task Completed", task_id=task_id, task=task_info)
@@ -186,7 +201,7 @@ class TaskManager:
             )
             state = TaskState.FAILED
             logger.opt(exception=exc).error(
-                "Task failed", task_id=task_id, task=task_info, exception=exc
+                "Tasky Failed", task_id=task_id, task=task_info, exception=exc
             )
             task_info["last_error"] = str(exc)
         task_info["state"] = state
@@ -248,8 +263,8 @@ class TaskManager:
         future = self._executor.submit(task_mapping[task], *args, **kwargs)
         info["state"] = TaskState.RUNNING
         self.save_task(task_id, info)
-        future.add_done_callback(lambda _: self.done_callback(task_id))
         self._tasks[task_id] = {"future": future, "info": info}
+        future.add_done_callback(lambda _: self.done_callback(task_id))
         return task_id
 
     def shutdown(self, timeout: int):

--- a/rawfile/utils/task_manager.py
+++ b/rawfile/utils/task_manager.py
@@ -1,11 +1,12 @@
 from concurrent.futures import Executor, Future
 from enum import StrEnum
 import shutil
-from typing import Callable, TypedDict
+from typing import Callable, TypedDict, NotRequired
 import time
 from config import config
 from utils.snapshot_manager import manager as snapshot_manager
 from utils.volume_manager import manager as volume_manager
+from datetime import datetime
 from pathlib import Path
 import json
 import hashlib
@@ -43,6 +44,11 @@ class TaskInfo(TypedDict):
     kwargs: dict
     retry_count: int
     state: TaskState
+
+    created_ts: NotRequired[datetime]  # When the task was first created
+    saved_ts: NotRequired[datetime]  # When the task was last saved
+    retry_ts: NotRequired[datetime]  # When the current retry attempt began
+    last_error: NotRequired[str]  # Last error hit by the task
 
 
 class TaskManager:
@@ -90,9 +96,9 @@ class TaskManager:
         logger.debug("Retrying all retriable tasks", running=len(self._tasks))
         for task_id, failed_task in self.get_tasks(retriable=True).items():
             logger.debug("Retrying task", task_id=task_id, task=failed_task)
-            self.remove_task(task_id)
-            self.run_task(
+            self.run_task_ext(
                 TaskName(failed_task["task"]),
+                True,
                 *failed_task["args"],
                 **failed_task["kwargs"],
             )
@@ -123,10 +129,36 @@ class TaskManager:
                         }
                 if state is not None:
                     data = {k: v for k, v in data.items() if v["state"] == state}
+                for k, v in list(data.items()):
+                    data[k] = self.decode_task(v)
                 return data
 
     def get_task(self, task_id) -> None:
-        self.get_tasks().get(task_id, None)
+        self.get_tasks().get(task_id)
+
+    def encode_task(self, task: TaskInfo) -> dict:
+        out = dict(task)
+        for key in ("created_ts", "saved_ts", "retry_ts"):
+            value = out.get(key, None)
+            if isinstance(value, datetime):
+                out[key] = value.isoformat()
+        return out
+
+    def maybe_dt(self, value: str | None) -> datetime:
+        if isinstance(value, str):
+            try:
+                return datetime.fromisoformat(value)
+            except ValueError:
+                return None
+        return None
+
+    def decode_task(self, raw: dict) -> TaskInfo:
+        return {
+            **raw,
+            "created_ts": self.maybe_dt(raw.get("created_ts")),
+            "saved_ts": self.maybe_dt(raw.get("saved_ts")),
+            "retry_ts": self.maybe_dt(raw.get("retry_ts")),
+        }
 
     def remove_task(self, task_id: str):
         logger.debug("Removing task", task_id=task_id)
@@ -156,36 +188,62 @@ class TaskManager:
             logger.opt(exception=exc).error(
                 "Task failed", task_id=task_id, task=task_info, exception=exc
             )
+            task_info["last_error"] = str(exc)
         task_info["state"] = state
         self.save_task(task_id, task_info)
 
     def save_task(self, task_id: str, task_info: TaskInfo):
         with self._lock:
             logger.debug("Saving task", task_id=task_id, task=task_info)
+            task_info["saved_ts"] = datetime.now()
             with open(self._tasks_store_path, "r+") as tasks_file:
                 current: dict[str, TaskInfo] = json.loads(tasks_file.read() or "{}")
-                current[task_id] = task_info
+                current[task_id] = self.encode_task(task_info)
                 tasks_file.truncate(0)
                 tasks_file.seek(0)
                 json.dump(current, tasks_file)
                 os.fsync(tasks_file.fileno())
 
-    def run_task(self, task: TaskName, *args, **kwargs) -> str:
+    def run_task(
+        self,
+        task: TaskName,
+        *args,
+        **kwargs,
+    ) -> str:
+        return self.run_task_ext(task, False, *args, **kwargs)
+
+    def run_task_ext(
+        self,
+        task: TaskName,
+        retry: bool,
+        *args,
+        **kwargs,
+    ) -> str:
         logger.debug("Running task", task=task.value, args=args, kwargs=kwargs)
         if self._shutting_down:
             raise TaskManagerShuttingDown()
         task_id = self.hash_task_info(task, *args, **kwargs)
         current = self.get_task(task_id) or {}
         retry_count = current.get("retry_count", -1)
-        if current.get("state", None):
+        last_error = current.get("last_error", None)
+
+        if not retry and current.get("state", None):
+            # if it's a csi request
             return task_id
+
         info: TaskInfo = {
             "kwargs": kwargs,
             "task": task.value,
             "args": list(args),
             "retry_count": retry_count,
             "state": TaskState.PENDING,
+            "created_ts": datetime.now(),
         }
+        if retry and current.get("state", None):
+            info["retry_ts"] = datetime.now()
+            if last_error is not None:
+                info["last_error"] = last_error
+
         self.save_task(task_id, info)
         future = self._executor.submit(task_mapping[task], *args, **kwargs)
         info["state"] = TaskState.RUNNING

--- a/rawfile/utils/volume_manager.py
+++ b/rawfile/utils/volume_manager.py
@@ -251,6 +251,7 @@ class VolumeManager:
         return [basename(dirname(meta)) for meta in metas]
 
     def gc_all_volumes(self, dry_run=True):
+        logger.info("Running Volume Metadata Garbage Collection", dry_run=dry_run)
         return [
             self.gc_if_needed(volume_id, dry_run=dry_run)
             for volume_id in self.list_all_volumes()


### PR DESCRIPTION
    test: log snapshot data with command
    
    Don't we also need to check if the expected data is correct???
    
---

    fix: store in-memory task before submission
    
    Otherwise we may get callback with no task stored.
    Also cater for this by logging an error and exiting if we ever
    encounter this scenario again as this could crash the task_manager.
    
---

    feat: enrich task information with timestamps and error
    
    Adds created, saved and retried timestmap - this should make it easier
    to understand the state of a task.
    
    Also added last error to the task, so we can find out why
    a task was saved as failed.
    
---

    fix: handle crash of the TaskManager retry worker
    
    In case there's errors during the task manager worker, then
    we catch this error, and log it.
    
    Since we don't run the tasks directly (we only schedule them), we
    should not be facing any errors here other than those related to
    encode/decode of the tasks.json and any I/O errors reading/writing it.
    
    In the future we may want to trigger a container graceful shutdown, thus
    making this error more visible.
    Alternatively, we could expose this via prometheus metrics.

---

    chore: log all the volumes that require GC
    
    Currently we don't seem to be GCing all volumes.
    We now always run the GC with dryRun so we can at least log
    all the volumes at node plugin startup.

---

    style: don't log attached loops query
    
    This ends up flooding the log and it's probably not that useful now
    If we add a trace level we could make it a trace log
    
---

    dev: git ignore .vscode dir
