### PR TITLE
fix: GetCapacity calls for freshly created volumes

### DIFF
--- a/rawfile/utils/volume_manager.py
+++ b/rawfile/utils/volume_manager.py
@@ -263,14 +263,21 @@ class VolumeManager:
             pool = meta.get("storage_pool", config.csi_driver.default_pool)
             thin_provision = meta.get("thin_provision", False)
             file = img_file(volume_id=volume_id)
+
+            try:
+                file_stats = stat(file)
+            except FileNotFoundError:
+                return None
+
             loop_devs = attached_loops(file.as_posix())
-            if not (loop_devs and len(loop_devs)):
-                return None
-            mountpoint = device_to_mountpoint(loop_devs[0])
-            if not mountpoint:
-                return None
-            filesystem_stats = statvfs(mountpoint)
-            file_stats = stat(file)
+            if loop_devs and len(loop_devs):
+                mountpoint = device_to_mountpoint(loop_devs[0])
+                if mountpoint:
+                    filesystem_stats = statvfs(mountpoint)
+                else:
+                    filesystem_stats = {"fs_usage": 0}
+            else:
+                filesystem_stats = {"fs_usage": 0}
 
             # note that "sparse" here might differ from metadata's
             # "thin_provision": if the volume was created as thick but formatted


### PR DESCRIPTION
Fix the behaviour where a freshly created volume may not affect the available
capacity leading to unwanted overprovisioning.

CreateVolume -> GetCapacity -> NodeStageVolume call sequence means that
effectively the volume won't be formatted or mounted at the time GetCapacity is
called. Thus the proposed change: volume_stats() are still returned even if the
volume is not yet attached as a loopdev or formatted. The only stat depending on
it is used space in terms of filesystem, and it's used only in metrics now.

That opens the possibility to create a lot of volumes in a short amount of time,
filling up the whole disk, effectively ignoring `reserved_capacity`, triggering
kubelet DiskPressure and evicting pods from the node (ask me how I know :) )