### PR TITLE
ci: update setup trivy version

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           driver-opts: |
             network=host
-      - uses: aquasecurity/setup-trivy@v0.2.4
+      - uses: aquasecurity/setup-trivy@v0.2.6
       - name: Build and scan image
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The setup trivy action was compromised. See : https://github.com/aquasecurity/setup-trivy/issues/31
The older versions (releases/tags) were removed from the https://github.com/aquasecurity/setup-trivy/releases

I tried dependabot to update but it says that the package is no longer vulnerable and hence it does not update, hence the manual PR.