### PR TITLE
feat: add node.podAnnotations to DaemonSet pod template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added ✨
 - Added `csiSideCars.image.registry` and `csiSideCars.image.pullPolicy` to configure CSI sidecar container images
 - Added `analytics.enabled` to enable/disable analytics locally
+- Added `node.podAnnotations` to set custom annotations on the node DaemonSet pods
 
 ### Fixed 🐛
 

--- a/deploy/helm/rawfile-localpv/README.md
+++ b/deploy/helm/rawfile-localpv/README.md
@@ -90,6 +90,7 @@ Please follow the [install guide](https://github.com/openebs/rawfile-localpv/tre
 | node.metadataDirPath | string | `"/var/local/openebs/rawfile/{{ .Release.Name }}/meta"` | Metadata dir path for rawfile volumes metadata and tasks store file |
 | node.metrics.enabled | bool | `false` |  |
 | node.nodeSelector | string | `nil` | nodeSelector for node component |
+| node.podAnnotations | object | `{}` | Annotations for the node DaemonSet pods |
 | node.priorityClassName | string | `"system-node-critical"` | priorityClassName for node component since this part is critical for node `system-node-critical` is default |
 | node.resources | object | `{}` | Sets compute resources for node component |
 | node.snapshotController.image.pullPolicy | string | `nil` | Image pull policy for `snapshot-controller` |

--- a/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
+++ b/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
@@ -13,6 +13,10 @@ spec:
   template:
     metadata:
       labels: *selectorLabels
+      {{- with .Values.node.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccount: {{ include "rawfile-localpv.fullname" . }}-driver
       priorityClassName: {{ .Values.node.priorityClassName }}

--- a/deploy/helm/rawfile-localpv/values.yaml
+++ b/deploy/helm/rawfile-localpv/values.yaml
@@ -199,6 +199,9 @@ node:
   # -- Affinities for node component
   affinity:
 
+  # -- Annotations for the node DaemonSet pods
+  podAnnotations: {}
+
   # -- Number of gRPC workers for node component
   grpcWorkers: 10
 


### PR DESCRIPTION
## What

Add a new `node.podAnnotations` value that lets operators set custom
annotations on the node DaemonSet's pod template.

## Why

Operators commonly need to attach annotations to running pods — for
service-mesh sidecar injection, scheduling hints, monitoring/scraping
configuration, and other operational metadata. The chart already
supports this kind of customization for the controller-side via
`tolerations`, `nodeSelector`, and `affinity`, but there is currently
no way to add pod annotations to the node DaemonSet without forking
the chart.

This adds the missing knob, defaulting to `{}` so existing deployments
are unaffected.

## How

- New `node.podAnnotations` key in `values.yaml` (default `{}`)
- Conditional `annotations:` block in
  `templates/node-plugin/daemonset.yaml` rendered only when the map is
  non-empty (no stray empty annotations block in the default case)
- CHANGELOG entry under `[Unreleased] → Added`

## Verification

- `helm template` with `--set 'node.podAnnotations.foo=bar'` renders
  the annotation under the pod template metadata
- `helm template` with no `node.podAnnotations` set produces no
  `annotations:` key at all (clean default)
- `helm lint` passes

## Example usage

Adding Prometheus pod-level scrape annotations so the rawfile-localpv
metrics endpoint gets discovered and scraped by a Prometheus instance
configured for the standard `kubernetes_pod` service-discovery role:

```yaml
# values.yaml
node:
  podAnnotations:
    prometheus.io/scrape: "true"
    prometheus.io/port: "9100"
    prometheus.io/path: "/metrics"
metrics:
  enabled: true
  port: 9100