### PR TITLE
feat(metrics): per-pool and per-volume Prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `csiSideCars.image.registry` and `csiSideCars.image.pullPolicy` to configure CSI sidecar container images
 - Added `analytics.enabled` to enable/disable analytics locally
 - Added `node.podAnnotations` to set custom annotations on the node DaemonSet pods
+- Added per-storage-pool Prometheus metrics (`rawfile_pool_capacity_bytes`, `rawfile_pool_available_bytes`, `rawfile_pool_usage_bytes`, `rawfile_pool_reserved_capacity_bytes`, `rawfile_pool_remaining_capacity_bytes`, `rawfile_pool_volumes_physical_bytes`, `rawfile_pool_volumes_logical_bytes`, `rawfile_pool_volume_count`, `rawfile_pool_info`) and per-volume additions (`rawfile_volume_physical_bytes`, `rawfile_volume_info`); existing `rawfile_remaining_capacity_bytes`, `rawfile_volume_used_bytes`, and `rawfile_volume_total_bytes` are unchanged
 
 ### Fixed 🐛
 
@@ -28,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ReadOnly attribute in PVC template not fully handled
 - When using thin provisioning, user must specify the format options preventing `mkfs` from discarding blocks (`-K` for xfs/btrfs, `-E nodiscard` for ext4). Also see this [issue](https://github.com/openebs/rawfile-localpv/issues/295)
-- Prometheus metrics use capacity sum across all the pools, instead of values per pool. This may lead to confusing results. Also see this [issue](https://github.com/openebs/rawfile-localpv/issues/294)
 - For ext4, volumes available space might be smaller than intended due to defaulting to reserve 5% of the blocks for privileged users. This can be circumvented via format options (`-m 0`)
 
 ---

--- a/rawfile/metrics.py
+++ b/rawfile/metrics.py
@@ -1,7 +1,8 @@
 from prometheus_client.core import REGISTRY
 from prometheus_client.exposition import start_http_server
 from prometheus_client.metrics_core import GaugeMetricFamily
-from utils.storage_pool import get_capacity
+from utils.devices import statvfs
+from utils.storage_pool import get_capacity, reserved_capacity_handlers
 from utils.volume_manager import manager as volume_manager
 from config import config
 
@@ -20,14 +21,77 @@ class VolumeStatsCollector(object):
     def __init__(self, node):
         self.node = node
 
-    # TODO (pgu, 09.02.2026): should these metrics be per node per pool?
     def collect(self):
+        """Emit one snapshot of every rawfile metric family.
+
+        Gauges are organised into three groups by aggregation level:
+
+        - Node-level: a single per-node aggregate.
+        - Per-pool: labelled by ``pool``, for visibility into each storage
+          pool individually when multiple pools are configured.
+        - Per-volume: labelled by ``volume``, for per-PVC granularity.
+
+        """
         remaining_capacity = GaugeMetricFamily(
             "rawfile_remaining_capacity",
             "Free capacity for new volumes on this node (excluding reserved storage).",
             labels=["node"],
             unit="bytes",
         )
+
+        pool_capacity = GaugeMetricFamily(
+            "rawfile_pool_capacity",
+            "Total size of the filesystem backing the storage pool.",
+            labels=["node", "pool"],
+            unit="bytes",
+        )
+        pool_available = GaugeMetricFamily(
+            "rawfile_pool_available",
+            "Available space on the filesystem backing the storage pool, as reported by statvfs.",
+            labels=["node", "pool"],
+            unit="bytes",
+        )
+        pool_usage = GaugeMetricFamily(
+            "rawfile_pool_usage",
+            "Used space on the filesystem backing the storage pool, as reported by statvfs.",
+            labels=["node", "pool"],
+            unit="bytes",
+        )
+        pool_reserved = GaugeMetricFamily(
+            "rawfile_pool_reserved_capacity",
+            "Bytes reserved on the storage pool's backing filesystem according to its reserved_capacity configuration.",
+            labels=["node", "pool"],
+            unit="bytes",
+        )
+        pool_remaining = GaugeMetricFamily(
+            "rawfile_pool_remaining_capacity",
+            "Free capacity for new volumes on the storage pool (excluding reserved storage).",
+            labels=["node", "pool"],
+            unit="bytes",
+        )
+        pool_volumes_physical = GaugeMetricFamily(
+            "rawfile_pool_volumes_physical",
+            "Sum of physical (on-disk) sizes of all volumes in the storage pool.",
+            labels=["node", "pool"],
+            unit="bytes",
+        )
+        pool_volumes_logical = GaugeMetricFamily(
+            "rawfile_pool_volumes_logical",
+            "Sum of logical (provisioned) sizes of all volumes in the storage pool.",
+            labels=["node", "pool"],
+            unit="bytes",
+        )
+        pool_volume_count = GaugeMetricFamily(
+            "rawfile_pool_volume_count",
+            "Number of volumes provisioned on the storage pool.",
+            labels=["node", "pool"],
+        )
+        pool_info = GaugeMetricFamily(
+            "rawfile_pool_info",
+            "Static information about a storage pool. Always 1; use labels for join.",
+            labels=["node", "pool", "mode", "default_pool"],
+        )
+
         volume_used = GaugeMetricFamily(
             "rawfile_volume_used",
             "Actual amount of disk used space by volume",
@@ -40,11 +104,95 @@ class VolumeStatsCollector(object):
             labels=["node", "volume"],
             unit="bytes",
         )
+        volume_physical = GaugeMetricFamily(
+            "rawfile_volume_physical",
+            "Physical (on-disk) size of the volume's backing file.",
+            labels=["node", "volume"],
+            unit="bytes",
+        )
+        volume_info = GaugeMetricFamily(
+            "rawfile_volume_info",
+            "Static information about a volume. Always 1; use labels for join.",
+            labels=["node", "volume", "pool", "sparse", "thin_provision"],
+        )
+
+        all_volumes_stats = volume_manager.get_all_volumes_stats()
+
         remaining_capacity.add_metric([self.node], get_remaining_capacity())
-        for volume_id, stats in volume_manager.get_all_volumes_stats().items():
+        for volume_id, stats in all_volumes_stats.items():
             volume_used.add_metric([self.node, volume_id], stats["used"])
             volume_total.add_metric([self.node, volume_id], stats["logical_size"])
-        return [remaining_capacity, volume_used, volume_total]
+            volume_physical.add_metric([self.node, volume_id], stats["physical_size"])
+            volume_info.add_metric(
+                [
+                    self.node,
+                    volume_id,
+                    stats["pool"],
+                    str(stats["sparse"]),
+                    str(stats["thin_provision"]),
+                ],
+                1,
+            )
+
+        storage_pools = (
+            getattr(getattr(config, "csi_driver", None), "storage_pools", None) or {}
+        )
+        default_pool = getattr(
+            getattr(config, "csi_driver", None), "default_pool", None
+        )
+
+        for pool_name, pool in storage_pools.items():
+            try:
+                fs_stats = statvfs(pool.path)
+            except (FileNotFoundError, OSError):
+                # Pool path not yet available.
+                continue
+
+            reserved_bytes = reserved_capacity_handlers[pool.reserved_capacity_mode](
+                fs_stats["fs_size"], pool.reserved_capacity
+            )
+            pool_capacity.add_metric([self.node, pool_name], fs_stats["fs_size"])
+            pool_available.add_metric([self.node, pool_name], fs_stats["fs_avail"])
+            pool_usage.add_metric([self.node, pool_name], fs_stats["fs_usage"])
+            pool_reserved.add_metric([self.node, pool_name], reserved_bytes)
+            pool_remaining.add_metric([self.node, pool_name], get_capacity(pool_name))
+            pool_info.add_metric(
+                [
+                    self.node,
+                    pool_name,
+                    pool.reserved_capacity_mode.value,
+                    str(pool_name == default_pool),
+                ],
+                1,
+            )
+
+            phys_total = log_total = volume_count = 0
+            for stats in all_volumes_stats.values():
+                if stats.get("pool") != pool_name:
+                    continue
+                phys_total += stats["physical_size"]
+                log_total += stats["logical_size"]
+                volume_count += 1
+            pool_volumes_physical.add_metric([self.node, pool_name], phys_total)
+            pool_volumes_logical.add_metric([self.node, pool_name], log_total)
+            pool_volume_count.add_metric([self.node, pool_name], volume_count)
+
+        return [
+            remaining_capacity,
+            pool_capacity,
+            pool_available,
+            pool_usage,
+            pool_reserved,
+            pool_remaining,
+            pool_volumes_physical,
+            pool_volumes_logical,
+            pool_volume_count,
+            pool_info,
+            volume_used,
+            volume_total,
+            volume_physical,
+            volume_info,
+        ]
 
 
 def expose_metrics(node, port):


### PR DESCRIPTION
## Summary

Adds per-pool and per-volume Prometheus metrics so operators can see capacity attribution at a more useful granularity. Existing metrics are preserved verbatim — this change is purely additive.

Closes #294.

## Motivation

The current `rawfile_remaining_capacity_bytes` collapses every storage pool on a node into a single number. For deployments that run multiple pools (or are planning to), this hides which pool is filling up. The per-volume side has the inverse problem: `rawfile_volume_used_bytes` and `rawfile_volume_total_bytes` expose what's mounted but not the underlying file size or any of the provisioning metadata, so it's hard to distinguish thin from thick volumes or attribute usage to a particular pool.

This MR fills both gaps by exposing the per-pool and per-volume data that's already available inside `volume_manager` and `storage_pool` — no behavioural changes to the driver, just new metric families.

## New metrics

### Per-pool (labels: `node`, `pool`)

| Metric | Description |
|---|---|
| `rawfile_pool_capacity_bytes` | Total size of the filesystem backing the storage pool (`statvfs.fs_size`) |
| `rawfile_pool_available_bytes` | Free space on the backing filesystem (`statvfs.fs_avail`) |
| `rawfile_pool_usage_bytes` | Used space on the backing filesystem (`fs_size − fs_avail`). Counts everything on the mount, not just rawfile files |
| `rawfile_pool_reserved_capacity_bytes` | Bytes reserved per `reserved_capacity` + `reserved_capacity_mode` |
| `rawfile_pool_remaining_capacity_bytes` | Free capacity for new volumes on the pool — `get_capacity(pool)` |
| `rawfile_pool_volumes_physical_bytes` | Sum of physical (on-disk, `st_blocks*512`) sizes of all volumes in the pool |
| `rawfile_pool_volumes_logical_bytes` | Sum of logical (provisioned) sizes of all volumes in the pool |
| `rawfile_pool_volume_count` | Number of volumes provisioned on the pool |
| `rawfile_pool_info` (=1) | Info series. Extra labels: `mode` (`plain` / `subtract-from-total`), `default_pool` (`True` / `False`) |

### Per-volume additions (labels: `node`, `volume`)

| Metric | Description |
|---|---|
| `rawfile_volume_physical_bytes` | Physical (on-disk) size of the volume's backing file |
| `rawfile_volume_info` (=1) | Info series. Extra labels: `pool`, `sparse`, `thin_provision` |

### Existing metrics — unchanged

`rawfile_remaining_capacity_bytes`, `rawfile_volume_used_bytes`, and `rawfile_volume_total_bytes` are kept verbatim. 

## Invariants preserved by construction

The new per-pool aggregate sums to the existing node-level aggregate — same underlying function, evaluated per pool vs. summed across pools:

```
rawfile_remaining_capacity_bytes{node}
  ==  Σ pool rawfile_pool_remaining_capacity_bytes{node, pool}
```

Within each pool, two `statvfs` identities hold:

```
rawfile_pool_capacity_bytes   ==  rawfile_pool_usage_bytes
                                + rawfile_pool_available_bytes

rawfile_pool_remaining_capacity_bytes
  ==  max(min(fs_size − reserved − volumes_physical, fs_avail), 0)
```

The implementation calls a single `volume_manager.get_all_volumes_stats()` per scrape and reuses the result for both per-volume series and per-pool aggregates, so there's no extra metadata-scan cost over the existing collector.
