### PR TITLE
fix(metrics): rawfile_pool_capacity metrics semantic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `csiSideCars.image.registry` and `csiSideCars.image.pullPolicy` to configure CSI sidecar container images
 - Added `analytics.enabled` to enable/disable analytics locally
 - Added `node.podAnnotations` to set custom annotations on the node DaemonSet pods
-- Added per-storage-pool Prometheus metrics (`rawfile_pool_capacity_bytes`, `rawfile_pool_available_bytes`, `rawfile_pool_usage_bytes`, `rawfile_pool_reserved_capacity_bytes`, `rawfile_pool_remaining_capacity_bytes`, `rawfile_pool_volumes_physical_bytes`, `rawfile_pool_volumes_logical_bytes`, `rawfile_pool_volume_count`, `rawfile_pool_info`) and per-volume additions (`rawfile_volume_physical_bytes`, `rawfile_volume_info`); existing `rawfile_remaining_capacity_bytes`, `rawfile_volume_used_bytes`, and `rawfile_volume_total_bytes` are unchanged
+- Added per-storage-pool Prometheus metrics (`rawfile_pool_capacity_bytes`, `rawfile_pool_backing_fs_capacity_bytes`, `rawfile_pool_available_bytes`, `rawfile_pool_usage_bytes`, `rawfile_pool_reserved_capacity_bytes`, `rawfile_pool_remaining_capacity_bytes`, `rawfile_pool_volumes_physical_bytes`, `rawfile_pool_volumes_logical_bytes`, `rawfile_pool_volume_count`, `rawfile_pool_info`) and per-volume additions (`rawfile_volume_physical_bytes`, `rawfile_volume_info`); existing `rawfile_remaining_capacity_bytes`, `rawfile_volume_used_bytes`, and `rawfile_volume_total_bytes` are unchanged. Note: `rawfile_pool_capacity_bytes` reflects the pool's allocated capacity (`fs_size − reserved_capacity`), matching the driver's internal "capacity reserved for this pool" model; `rawfile_pool_backing_fs_capacity_bytes` exposes the raw filesystem size from statvfs.
 
 ### Fixed 🐛
 

--- a/rawfile/metrics.py
+++ b/rawfile/metrics.py
@@ -41,7 +41,15 @@ class VolumeStatsCollector(object):
 
         pool_capacity = GaugeMetricFamily(
             "rawfile_pool_capacity",
-            "Total size of the filesystem backing the storage pool.",
+            "Capacity allocated to the storage pool for volume provisioning "
+            "(backing filesystem size minus reserved capacity).",
+            labels=["node", "pool"],
+            unit="bytes",
+        )
+        pool_backing_fs_capacity = GaugeMetricFamily(
+            "rawfile_pool_backing_fs_capacity",
+            "Total size of the filesystem backing the storage pool, "
+            "as reported by statvfs (fs_size).",
             labels=["node", "pool"],
             unit="bytes",
         )
@@ -151,7 +159,12 @@ class VolumeStatsCollector(object):
             reserved_bytes = reserved_capacity_handlers[pool.reserved_capacity_mode](
                 fs_stats["fs_size"], pool.reserved_capacity
             )
-            pool_capacity.add_metric([self.node, pool_name], fs_stats["fs_size"])
+            pool_capacity.add_metric(
+                [self.node, pool_name], fs_stats["fs_size"] - reserved_bytes
+            )
+            pool_backing_fs_capacity.add_metric(
+                [self.node, pool_name], fs_stats["fs_size"]
+            )
             pool_available.add_metric([self.node, pool_name], fs_stats["fs_avail"])
             pool_usage.add_metric([self.node, pool_name], fs_stats["fs_usage"])
             pool_reserved.add_metric([self.node, pool_name], reserved_bytes)
@@ -180,6 +193,7 @@ class VolumeStatsCollector(object):
         return [
             remaining_capacity,
             pool_capacity,
+            pool_backing_fs_capacity,
             pool_available,
             pool_usage,
             pool_reserved,


### PR DESCRIPTION
`storage_pool.py:49-50` defines the pool's capacity as:

```python
# reserved_capacity is the capacity reserved for everything else but this pool
# so the capacity reserved for this pool is (disk_total_size - reserved_capacity)
```

But `rawfile_pool_capacity_bytes` metric was exposing `statvfs.fs_size` directly — the FS size, not the pool's allocated capacity. Thus fixing the metric calculation and exposing an additional rawfile_pool_backing_fs_capacity_bytes for the backing filesystem size.
