### PR TITLE
feat(metrics): rename rawfile_pool_{usage,available} → rawfile_pool_b…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - YYYY-MM-DD
 
 ### Added ✨
+- Added `rawfile_pool_backing_fs_available_bytes` and `rawfile_pool_backing_fs_usage_bytes` metrics, exposing `statvfs(fs_avail)` and `statvfs(fs_size - fs_avail)` for the storage pool's backing filesystem. Replace the (v0.14.0) `rawfile_pool_available_bytes` / `rawfile_pool_usage_bytes`. The rename completes the `rawfile_pool_backing_fs_*` naming convention introduced in v0.14.0 with `rawfile_pool_backing_fs_capacity_bytes`: any metric measuring the whole backing filesystem (not just the rawfile-allocated slice) carries the `_backing_fs_` infix, so a single look at a metric name tells you whether it's pool-scoped or backing-FS-scoped.
 
 ### Fixed 🐛
 
@@ -17,7 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed ♻️
 
-### Removed 🗑️
+### Removed 🗑️ ⚠️
+- ⚠️ Removed `rawfile_pool_available_bytes` and `rawfile_pool_usage_bytes`. They were introduced in v0.14.0 with an inconsistent name (used the `rawfile_pool_*` prefix despite measuring the **backing filesystem** including non-rawfile tenants). Use the equivalently-valued replacements:
+  ```
+  rawfile_pool_available_bytes  →  rawfile_pool_backing_fs_available_bytes
+  rawfile_pool_usage_bytes      →  rawfile_pool_backing_fs_usage_bytes
+  ```
+  Anyone using these in dashboards or alerts will need to do a metric-name find/replace.
 
 ### Internal 🔧
 

--- a/rawfile/metrics.py
+++ b/rawfile/metrics.py
@@ -53,15 +53,21 @@ class VolumeStatsCollector(object):
             labels=["node", "pool"],
             unit="bytes",
         )
-        pool_available = GaugeMetricFamily(
-            "rawfile_pool_available",
-            "Available space on the filesystem backing the storage pool, as reported by statvfs.",
+        pool_backing_fs_available = GaugeMetricFamily(
+            "rawfile_pool_backing_fs_available",
+            "Available space on the filesystem backing the storage pool, "
+            "as reported by statvfs (fs_avail). Counts free space across the "
+            "whole backing FS, including the rawfile-reserved slice; not just "
+            "what rawfile is allowed to use.",
             labels=["node", "pool"],
             unit="bytes",
         )
-        pool_usage = GaugeMetricFamily(
-            "rawfile_pool_usage",
-            "Used space on the filesystem backing the storage pool, as reported by statvfs.",
+        pool_backing_fs_usage = GaugeMetricFamily(
+            "rawfile_pool_backing_fs_usage",
+            "Used space on the filesystem backing the storage pool, "
+            "as reported by statvfs (fs_size - fs_avail). Counts everything "
+            "on the backing FS (rawfile-managed volumes plus non-rawfile "
+            "tenants like kubelet ephemeral storage and container logs).",
             labels=["node", "pool"],
             unit="bytes",
         )
@@ -165,8 +171,12 @@ class VolumeStatsCollector(object):
             pool_backing_fs_capacity.add_metric(
                 [self.node, pool_name], fs_stats["fs_size"]
             )
-            pool_available.add_metric([self.node, pool_name], fs_stats["fs_avail"])
-            pool_usage.add_metric([self.node, pool_name], fs_stats["fs_usage"])
+            pool_backing_fs_available.add_metric(
+                [self.node, pool_name], fs_stats["fs_avail"]
+            )
+            pool_backing_fs_usage.add_metric(
+                [self.node, pool_name], fs_stats["fs_usage"]
+            )
             pool_reserved.add_metric([self.node, pool_name], reserved_bytes)
             pool_remaining.add_metric([self.node, pool_name], get_capacity(pool_name))
             pool_info.add_metric(
@@ -194,8 +204,8 @@ class VolumeStatsCollector(object):
             remaining_capacity,
             pool_capacity,
             pool_backing_fs_capacity,
-            pool_available,
-            pool_usage,
+            pool_backing_fs_available,
+            pool_backing_fs_usage,
             pool_reserved,
             pool_remaining,
             pool_volumes_physical,


### PR DESCRIPTION
The two metrics measure the backing filesystem (statvfs-derived,
including non-rawfile tenants) but had the bare rawfile_pool_* prefix
which implies pool-scope. This contradicts the convention established
in v0.14.0 where rawfile_pool_backing_fs_capacity_bytes was added
specifically to disambiguate scope.

Renaming completes the convention: rawfile_pool_* = pool-scoped
(rawfile's slice); rawfile_pool_backing_fs_* = backing-FS-scoped
(the whole filesystem).

Migration:
  rawfile_pool_available_bytes  →  rawfile_pool_backing_fs_available_bytes
  rawfile_pool_usage_bytes      →  rawfile_pool_backing_fs_usage_bytes