### PR TITLE
fix(taskmanager): fix taskmanager's task reader default retry_count values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed 🐛
 
+- When Task Manager would read tasks without "retry_count" key present, it'd throw a `KeyError` exception. Add defaults when "retry_count" key is read.
+
 ### Changed ♻️
 
 ### Removed 🗑️

--- a/rawfile/utils/task_manager.py
+++ b/rawfile/utils/task_manager.py
@@ -71,7 +71,7 @@ class TaskManager:
                 task_id=task_id,
                 task=task,
             )
-            if task["retry_count"] > 0:
+            if task.get("retry_count", self._max_retry + 1) > 0:
                 task["retry_count"] -= 1
             self.save_task(task_id, task)
         self._executor.submit(self.retry_worker)
@@ -118,14 +118,15 @@ class TaskManager:
                         data = {
                             k: v
                             for k, v in data.items()
-                            if v["retry_count"] < self._max_retry
+                            if v.get("retry_count", -1) < self._max_retry
                             and v["state"] == TaskState.FAILED
                         }
                     else:
                         data = {
                             k: v
                             for k, v in data.items()
-                            if v["retry_count"] >= self._max_retry
+                            if v.get("retry_count", self._max_retry + 1)
+                            >= self._max_retry
                         }
                 if state is not None:
                     data = {k: v for k, v in data.items() if v["state"] == state}


### PR DESCRIPTION
Some tasks don't have retry_count at all, so when reading those we might get errors accessing "retry_count" key if it's not there. This commit fixes it.