### PR TITLE
feat(chart): Add capacityPollInterval for externalProvisioner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added ✨
 - Added `rawfile_pool_backing_fs_available_bytes` and `rawfile_pool_backing_fs_usage_bytes` metrics, exposing `statvfs(fs_avail)` and `statvfs(fs_size - fs_avail)` for the storage pool's backing filesystem. Replace the (v0.14.0) `rawfile_pool_available_bytes` / `rawfile_pool_usage_bytes`. The rename completes the `rawfile_pool_backing_fs_*` naming convention introduced in v0.14.0 with `rawfile_pool_backing_fs_capacity_bytes`: any metric measuring the whole backing filesystem (not just the rawfile-allocated slice) carries the `_backing_fs_` infix, so a single look at a metric name tells you whether it's pool-scoped or backing-FS-scoped.
 
+- Helm chart:
+  - Add `capacityPollInterval` parameter for external-provisioner, determining how long the external-provisioner waits before checking for storage capacity changes.
+
 ### Fixed 🐛
 
 - When Task Manager would read tasks without "retry_count" key present, it'd throw a `KeyError` exception. Add defaults when "retry_count" key is read.

--- a/deploy/helm/rawfile-localpv/README.md
+++ b/deploy/helm/rawfile-localpv/README.md
@@ -72,6 +72,7 @@ Please follow the [install guide](https://github.com/openebs/rawfile-localpv/tre
 | node.driverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` | Image Repository for `csi-node-driver-registrar` |
 | node.driverRegistrar.image.tag | string | `"v2.13.0"` | Image Tag for `csi-node-driver-registrar` |
 | node.driverRegistrar.resources | object | `{}` | Sets compute resources for driver-registrar container |
+| node.externalProvisioner.capacityPollInterval | string | `"1m"` | Sets capacity poll interval for `csi-provisioner`, determining how long the external-provisioner waits before checking for storage capacity changes. |
 | node.externalProvisioner.image.pullPolicy | string | `nil` | Image pull policy for `csi-provisioner` |
 | node.externalProvisioner.image.registry | string | `""` | Image Registry for `csi-provisioner` |
 | node.externalProvisioner.image.repository | string | `"sig-storage/csi-provisioner"` | Image Repository for `csi-provisioner` |

--- a/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
+++ b/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
@@ -229,6 +229,7 @@ spec:
             - "--capacity-ownerref-level=1" # DaemonSet
             - "--node-deployment=true"
             - "--extra-create-metadata=true"
+            - "--capacity-poll-interval={{ .Values.node.externalProvisioner.capacityPollInterval }}"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/deploy/helm/rawfile-localpv/values.yaml
+++ b/deploy/helm/rawfile-localpv/values.yaml
@@ -129,6 +129,8 @@ node:
       tag: v5.2.0
       # -- Image pull policy for `csi-provisioner`
       pullPolicy:
+    # -- Sets capacity poll interval for `csi-provisioner`, determining how long the external-provisioner waits before checking for storage capacity changes.
+    capacityPollInterval: "1m"
 
   externalSnapshotter:
     # -- Sets compute resources for external-snapshotter container


### PR DESCRIPTION
Add capacityPollInterval to Helm chart values, parameter determining how long the external-provisioner waits before checking for storage capacity changes.