### PR TITLE
:recycle: Use CoW on snapshot restore when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed ♻️
 
+- Uses CoW when it's enabled and supported between source and destination on snapshot restore
+
 ### Removed 🗑️ ⚠️
 
 ### Internal 🔧

--- a/rawfile/rawfile.py
+++ b/rawfile/rawfile.py
@@ -60,7 +60,7 @@ def node_driver_preflight_checks(task_manager: task_manager.TaskManager):
     volume_manager.migrate_all_volume_schemas()
     task_manager.migrate_tasks_file_path()
     consts.COW_SUPPORT_MAP = {
-        name: is_cow_supported(pool.path)
+        name: is_cow_supported(pool.path, pool.path)
         for name, pool in config.csi_driver.storage_pools.items()
     }
 

--- a/rawfile/utils/rawfile.py
+++ b/rawfile/utils/rawfile.py
@@ -103,7 +103,7 @@ def update_permissions(volume_id: str, storage_pool: str) -> None:
     if not _img_dir.exists():
         return
     _img_dir.chmod(D_PERMS)
-    ## set permissions recursively on all files and dirs under the volume path
+    # set permissions recursively on all files and dirs under the volume path
     # we go 3 levels deep to cover most cases (img file, snapshots, temp snapshots, etc.)
     for each in chain(
         _img_dir.glob("**/*"), _img_dir.glob("**/**/*"), _img_dir.glob("**/**/**/*")
@@ -217,7 +217,7 @@ def be_symlink(path, to):
     path.symlink_to(to)
 
 
-def is_cow_supported(dir: Path) -> bool:
+def is_cow_supported(source_dir: Path, destination_dir: Path) -> bool:
     """Check if the filesystem at the given directory supports copy-on-write (COW) operations.
 
     This function attempts to create a temporary file in the specified directory,
@@ -230,11 +230,11 @@ def is_cow_supported(dir: Path) -> bool:
     Returns:
         bool: True if COW is supported, False otherwise.
     """
-    test_file = dir / ".cow_test_file"
-    clone_file = dir / ".cow_test_clone"
+    test_file = source_dir / ".cow_test_file"
+    clone_file = destination_dir / ".cow_test_clone"
     try:
         with open(test_file, "wb") as f:
-            f.write(b"test")
+            f.write(b"COW Support Test")
             f.flush()
             os.fsync(f.fileno())
         run(f"cp --reflink=always {test_file} {clone_file}")

--- a/rawfile/utils/snapshot_manager.py
+++ b/rawfile/utils/snapshot_manager.py
@@ -1,7 +1,8 @@
-from os import fsync
+import os
 from pathlib import Path
 import time
 from dataclasses import dataclass
+import consts
 from utils.commands import run
 from config import config
 from utils.errors import FsFreezeNotSupportedOnBlockVolumes, SnapshotCreateVolumeInUse
@@ -9,8 +10,8 @@ from utils.lock import VolLock
 from utils.rawfile import (
     attached_loops,
     img_file,
+    is_cow_supported,
     metadata,
-    patch_metadata,
     snapshots_dir,
 )
 from glob import glob
@@ -72,15 +73,6 @@ class SnapshotManager:
 
                 creation_time = time.time()
                 Path(f"{snap_path}.creating").unlink(missing_ok=True)
-                meta = metadata(volume_id)
-                reflink_attached = list(set(meta.get("reflink_attached", [])))
-                if copy_on_write:
-                    reflink_attached.append(name)
-                patch_metadata(
-                    volume_id,
-                    meta.get("storage_pool", config.csi_driver.default_pool),
-                    {"reflink_attached": reflink_attached},
-                )
                 return Snapshot(
                     name=name,
                     volume_id=volume_id,
@@ -110,30 +102,26 @@ class SnapshotManager:
                 Path(f"{snap_path}.creating"),
             ):
                 path.unlink(missing_ok=True)
-            meta = metadata(volume_id)
-            reflink_attached = list(set(meta.get("reflink_attached", [])))
-            if name in reflink_attached:
-                reflink_attached.remove(name)
-                patch_metadata(
-                    volume_id,
-                    meta["storage_pool"],
-                    {"reflink_attached": reflink_attached},
-                )
 
     def restore_snapshot(
         self, volume_id: str, name: str, destination: Path, temporary: bool = False
     ):
         """Restore a snapshot"""
-        chunk_size = 1024 * 1024
+        volume_meta = metadata(volume_id)
         snap_path = self._get_snapshot_path(volume_id, name, temporary)
-        with open(snap_path, "rb") as src, open(destination, "wb") as dst:
-            while True:
-                buf = src.read(chunk_size)
-                if not buf:
-                    break
-                dst.write(buf)
-            dst.flush()
-            fsync(dst.fileno())
+        copy_on_write_param = volume_meta.get("copy_on_write", None)
+        copy_on_write = (
+            copy_on_write_param
+            if copy_on_write_param is not None
+            else consts.COW_SUPPORT_MAP.get(
+                volume_meta.get("storage_pool", None), False
+            )
+        ) and is_cow_supported(Path(os.path.dirname(snap_path)), destination)
+        reflink = "always" if copy_on_write else "never"
+        cmd = (
+            f"cp --sparse=auto --reflink={reflink} {snap_path} {destination.as_posix()}"
+        )
+        run(cmd, check=True)
 
     def list_snapshots(
         self,

--- a/rawfile/utils/volume_manager.py
+++ b/rawfile/utils/volume_manager.py
@@ -181,16 +181,9 @@ class VolumeManager:
         temp_snapshots = list(snapshots_dir(volume_id, temporary=True).glob("*"))
         total_snapshots = len(snapshots) + len(temp_snapshots)
         meta = metadata_or(volume_id)
-        if len(meta.get("reflink_attached", [])) > 0:
+        if total_snapshots > 0:
             logger.warning(
-                "Volume has COW Snapshots attached, skipping destroy, will be destoyed when all snapshots are removed",
-                volume_id=volume_id,
-                snapshots=total_snapshots,
-            )
-            return
-        elif total_snapshots > 0:
-            logger.warning(
-                "Volume has Snapshots(without COW) attached, will only remove volume data",
+                "Volume has Snapshots attached, will only remove volume data",
                 volume_id=volume_id,
                 snapshots=total_snapshots,
             )

--- a/rawfile/volume_schema.py
+++ b/rawfile/volume_schema.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Final
 
-LATEST_SCHEMA_VERSION: Final[int] = 6
+LATEST_SCHEMA_VERSION: Final[int] = 7
 
 
 def migrate_0_to_1(data: dict) -> dict:
@@ -41,6 +41,12 @@ def migrate_5_to_6(data: dict) -> dict:
 
     data["schema_version"] = 6
     data["storage_pool"] = config.csi_driver.default_pool
+    return data
+
+
+def migrate_6_to_7(data: dict) -> dict:
+    data["schema_version"] = 7
+    data.pop("reflink_attached", None)
     return data
 
 


### PR DESCRIPTION
Uses CoW when CoW is possible between source and destination also supports cloning between multiple pools

Resolves #309