### PR TITLE
feat(analytics): make GA analytics DNS nameservers configurable

### DIFF
--- a/deploy/helm/rawfile-localpv/README.md
+++ b/deploy/helm/rawfile-localpv/README.md
@@ -27,6 +27,7 @@ Please follow the [install guide](https://github.com/openebs/rawfile-localpv/tre
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | analytics.enabled | bool | `true` | Enable OpenEBS analytics which help track engine traction and usage. |
+| analytics.gaDnsNameservers | string | `"8.8.8.8:53"` | Comma-separated DNS nameservers (each optionally `ip:port`) used to resolve the analytics endpoint. Leave empty to use the cluster's default resolver (CoreDNS). |
 | auth.enabled | bool | `true` | Enables authentication for internal gRPC server |
 | auth.secretName | string | `""` | If managing secrets outside the chart, use this to reference the secret name; otherwise, leave empty. |
 | auth.token | string | `""` | Sets authentication token for internal gRPC server, will generate one if nothing provided |
@@ -50,6 +51,7 @@ Please follow the [install guide](https://github.com/openebs/rawfile-localpv/tre
 | csiSideCars.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for csi sidecars |
 | csiSideCars.image.registry | string | `"registry.k8s.io"` | Image registry for csi sidecars |
 | global.analytics.enabled | string | `nil` | Global override for GA analytics |
+| global.analytics.gaDnsNameservers | string | `nil` | Global override for DNS nameservers used to resolve the analytics endpoint |
 | global.imagePullPolicy | string | `""` | Global override for image pull policy |
 | global.imagePullSecrets | list | `[]` | Global image pull secrets (merged with local imagePullSecrets and not overridden) - secret |
 | global.imageRegistry | string | `""` | Global override for image registry |

--- a/deploy/helm/rawfile-localpv/templates/controller/deployment.yaml
+++ b/deploy/helm/rawfile-localpv/templates/controller/deployment.yaml
@@ -134,6 +134,13 @@ spec:
             - name: GA_KEY
               value: {{ .Values.analytics.gaKey | quote }}
             {{- end }}
+            {{- if .Values.global.analytics.gaDnsNameservers }}
+            - name: GA_DNS
+              value: {{ .Values.global.analytics.gaDnsNameservers | quote }}
+            {{- else if .Values.analytics.gaDnsNameservers }}
+            - name: GA_DNS
+              value: {{ .Values.analytics.gaDnsNameservers | quote }}
+            {{- end }}
             - name: INTERNAL_PORT
               value: {{ .Values.node.internalGRPC.port | toString | quote }}
             - name: NODE_DS

--- a/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
+++ b/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
@@ -107,6 +107,13 @@ spec:
             - name: GA_KEY
               value: {{ .Values.analytics.gaKey | quote }}
             {{- end }}
+            {{- if .Values.global.analytics.gaDnsNameservers }}
+            - name: GA_DNS
+              value: {{ .Values.global.analytics.gaDnsNameservers | quote }}
+            {{- else if .Values.analytics.gaDnsNameservers }}
+            - name: GA_DNS
+              value: {{ .Values.analytics.gaDnsNameservers | quote }}
+            {{- end }}
             - name: CSI_DRIVER__INTERNAL_IP
               valueFrom:
                 fieldRef:

--- a/deploy/helm/rawfile-localpv/values.yaml
+++ b/deploy/helm/rawfile-localpv/values.yaml
@@ -9,6 +9,8 @@ global:
   analytics:
     # -- Global override for GA analytics
     enabled:
+    # -- Global override for DNS nameservers used to resolve the analytics endpoint
+    gaDnsNameservers:
 
 # -- Image registry for CSI Sidecars
 csiSideCars:
@@ -50,6 +52,8 @@ image:
 analytics:
   # -- Enable OpenEBS analytics which help track engine traction and usage.
   enabled: true
+  # -- Comma-separated DNS nameservers (each optionally `ip:port`) used to resolve the analytics endpoint. Leave empty to use the cluster's default resolver (CoreDNS).
+  gaDnsNameservers: "8.8.8.8:53"
 
 controller:
   externalResizer:

--- a/rawfile/analytics/ga4/client.py
+++ b/rawfile/analytics/ga4/client.py
@@ -1,33 +1,48 @@
 from typing import Final
 import dns.resolver
+from dns.nameserver import Do53Nameserver
 from requests.adapters import HTTPAdapter
 import requests
 import tldextract
+
+from config import config
+from utils.net import split_host_port
 
 
 _GA4_COLLECT_URL: Final[str] = "https://www.google-analytics.com/mp/collect"
 
 
+def _parse_nameserver(entry: str) -> Do53Nameserver:
+    """Build a per-server ``Do53Nameserver`` from a validated ``host[:port]`` entry.
+
+    dnspython's resolver only accepts bare IP strings in ``nameservers`` (the port
+    lives on ``resolver.port``), so an explicit ``Do53Nameserver`` is needed to carry
+    a per-server port. Entries are validated at config load (see ``validate_ga_dns``).
+    """
+    host, port = split_host_port(entry)
+    return Do53Nameserver(host, int(port) if port else 53)
+
+
 class DNSAdapter(HTTPAdapter):
     def __init__(self, nameservers):
-        self.nameservers = nameservers
+        self.nameservers = [_parse_nameserver(ns) for ns in nameservers]
         super().__init__()
 
-    def resolve(self, host, nameservers, record_type):
+    def resolve(self, host, record_type):
         dns_resolver = dns.resolver.Resolver()
-        dns_resolver.nameservers = nameservers
-        answers = dns_resolver.query(host, record_type)
+        dns_resolver.nameservers = self.nameservers
+        answers = dns_resolver.resolve(host, record_type)
         for rdata in answers:
             return str(rdata)
 
     def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
         if not request.url:
-            raise
+            raise ValueError("request URL is not set")
         ext = tldextract.extract(request.url)
         fqdn = ".".join([ext.subdomain, ext.domain, ext.suffix])
-        a_record = self.resolve(fqdn, self.nameservers, "A")
+        a_record = self.resolve(fqdn, "A")
         if not a_record:
-            raise
+            raise RuntimeError(f"DNS resolution returned no A record for {fqdn}")
         resolved_url = request.url.replace(fqdn, a_record)
         request.url = resolved_url
         self.poolmanager.connection_pool_kw["server_hostname"] = fqdn
@@ -51,7 +66,10 @@ class GA4Client:
             "events": [{"name": event_name, "params": params}],
         }
         session = requests.Session()
-        session.mount("https://", DNSAdapter(["8.8.8.8"]))
+        # When nameservers are configured, resolve through them; otherwise leave DNS
+        # untouched so the request uses the system/pod default resolver (e.g. CoreDNS).
+        if config.ga_dns:
+            session.mount("https://", DNSAdapter(config.ga_dns))
         response = session.post(url, json=payload, timeout=60)
         response.raise_for_status()
         return response

--- a/rawfile/config/model.py
+++ b/rawfile/config/model.py
@@ -23,11 +23,13 @@ from pydantic_settings import (
     BaseSettings,
     CliSettingsSource,
     CliSubCommand,
+    NoDecode,
     PydanticBaseSettingsSource,
     SettingsConfigDict,
 )
 from utils.logs import LoggingFormats
 from utils.modeltypes import ReservedCapacityMode
+from utils.net import parse_nameservers
 
 NAME_REGEX: Final[re.Pattern] = re.compile(
     r"^(?=.{1,253}$)(?!.*\.\.)([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)(\.([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?))*$"
@@ -262,6 +264,24 @@ class RawFileCmd(
     node_ds: str | None = Field(
         default=None, description="Name of the node DS used for node discovery"
     )
+    # NoDecode: without it pydantic-settings JSON-decodes list env values *before*
+    # validators run, so a plain "GA_DNS=8.8.8.8:53" would raise SettingsError at
+    # startup. NoDecode hands the raw string to validate_ga_dns instead.
+    ga_dns: Annotated[list[str], NoDecode] = Field(
+        default=[],
+        description="""DNS nameservers used to resolve the Google Analytics collection endpoint.
+        Accepts a comma-separated string or a list; each entry may include a port, e.g.
+        "8.8.8.8:53" or "[2001:4860:4860::8888]:53". Leave empty to use the system/pod default
+        resolver (e.g. cluster CoreDNS).""",
+    )
+
+    @field_validator("ga_dns", mode="before")
+    @classmethod
+    def validate_ga_dns(cls, v):
+        # Validate up front so a typo surfaces at startup (as a warning) rather than
+        # as a swallowed per-request error later. See utils.net.parse_nameservers.
+        return parse_nameservers(v)
+
     gc: CliSubCommand[GCCmd] = Field(
         description="Runs GC for all volumes in the node",
     )

--- a/rawfile/tests/test_net.py
+++ b/rawfile/tests/test_net.py
@@ -1,0 +1,75 @@
+import pytest
+
+from utils.net import parse_nameservers, split_host_port
+
+
+@pytest.mark.parametrize(
+    "entry,expected",
+    [
+        ("8.8.8.8", ("8.8.8.8", "")),
+        ("8.8.8.8:53", ("8.8.8.8", "53")),
+        (" 8.8.8.8:53 ", ("8.8.8.8", "53")),  # surrounding whitespace stripped
+        ("::1", ("::1", "")),  # bare IPv6 (>1 colon) => no port
+        ("2001:4860:4860::8888", ("2001:4860:4860::8888", "")),
+        ("[2001:4860:4860::8888]:53", ("2001:4860:4860::8888", "53")),
+        ("[::1]", ("::1", "")),  # bracketed IPv6 without port
+    ],
+)
+def test_split_host_port(entry, expected):
+    assert split_host_port(entry) == expected
+
+
+def test_parse_nameservers_helm_default():
+    # The chart ships "8.8.8.8:53"; it must survive validation unchanged.
+    assert parse_nameservers("8.8.8.8:53") == ["8.8.8.8:53"]
+
+
+def test_parse_nameservers_comma_string():
+    assert parse_nameservers("8.8.8.8:53, 1.1.1.1 ,[::1]:5353") == [
+        "8.8.8.8:53",
+        "1.1.1.1",
+        "[::1]:5353",
+    ]
+
+
+def test_parse_nameservers_accepts_list():
+    assert parse_nameservers(["8.8.8.8", "1.1.1.1:53"]) == ["8.8.8.8", "1.1.1.1:53"]
+
+
+@pytest.mark.parametrize("value", ["", "   ", [], None])
+def test_parse_nameservers_empty_disables(value):
+    # Empty => no override => caller falls back to the system/pod resolver.
+    assert parse_nameservers(value) == []
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "8.8.8.8:9x",  # non-numeric port
+        "8.8.8.8:70000",  # port out of range
+        "dns.internal:53",  # hostname, not an IP
+        "not-an-ip",
+    ],
+)
+def test_parse_nameservers_drops_invalid_with_warning(bad):
+    with pytest.warns(UserWarning, match="Ignoring invalid DNS nameserver"):
+        assert parse_nameservers(bad) == []
+
+
+def test_parse_nameservers_keeps_valid_drops_invalid():
+    with pytest.warns(UserWarning, match="nope"):
+        assert parse_nameservers("8.8.8.8,nope,1.1.1.1:53") == [
+            "8.8.8.8",
+            "1.1.1.1:53",
+        ]
+
+
+def test_ga_dns_field_uses_nodecode():
+    # Regression guard: without NoDecode, pydantic-settings JSON-decodes list env
+    # values before validators run, so GA_DNS="8.8.8.8:53" would raise SettingsError
+    # at startup. Skips where the heavy config import chain isn't installed.
+    model = pytest.importorskip("config.model")
+    from pydantic_settings import NoDecode
+
+    metadata = model.RawFileCmd.model_fields["ga_dns"].metadata
+    assert any(m is NoDecode or isinstance(m, NoDecode) for m in metadata)

--- a/rawfile/utils/net.py
+++ b/rawfile/utils/net.py
@@ -1,0 +1,45 @@
+import ipaddress
+import warnings
+
+
+def split_host_port(entry: str) -> tuple[str, str]:
+    """Split a nameserver entry into ``(host, port)``.
+
+    Accepts ``"8.8.8.8"``, ``"8.8.8.8:53"``, ``"::1"``, or
+    ``"[2001:4860:4860::8888]:53"``. ``port`` is ``""`` when not present.
+    """
+    entry = entry.strip()
+    if entry.startswith("["):  # bracketed IPv6, optionally "[addr]:port"
+        host, _, port = entry[1:].partition("]")
+        return host, port.lstrip(":")
+    if entry.count(":") == 1:  # IPv4 "addr:port"
+        host, _, port = entry.partition(":")
+        return host, port
+    return entry, ""  # bare IPv4 or bare (unbracketed) IPv6
+
+
+def parse_nameservers(value) -> list[str]:
+    """Normalize a nameserver spec into a list of valid ``ip[:port]`` entries.
+
+    Accepts a comma-separated string or a list. Each entry must be a valid IP
+    address (v4/v6) with an optional port in ``0..65535``. Invalid entries are
+    dropped with a warning rather than raising, so a misconfigured value degrades
+    to the remaining valid servers (or an empty list) instead of failing hard.
+    """
+    entries = (
+        [s.strip() for s in value.split(",") if s.strip()]
+        if isinstance(value, str)
+        else value
+    )
+    valid = []
+    for entry in entries or []:
+        host, port = split_host_port(entry)
+        try:
+            ipaddress.ip_address(host)
+            if port != "" and not (0 <= int(port) <= 65535):
+                raise ValueError("port out of range")
+        except ValueError:
+            warnings.warn(f"Ignoring invalid DNS nameserver: {entry!r}")
+            continue
+        valid.append(entry)
+    return valid


### PR DESCRIPTION
## What

Makes the DNS nameservers used to resolve the Google Analytics collection
endpoint configurable, instead of the previously hardcoded `8.8.8.8`. Also
fixes several latent bugs in the analytics `DNSAdapter`.

## Why

The GA4 client resolved `www.google-analytics.com` through a custom adapter
that hardcoded `8.8.8.8` as the resolver. This is problematic:

- In clusters that restrict egress to public DNS, `:53` to `8.8.8.8` is
  blocked, so analytics fails even though cluster CoreDNS (→ upstream) would
  have resolved it fine.
- It bypasses cluster CoreDNS entirely.

It also modernizes a deprecated dnspython call — `Resolver.query()` (deprecated
since dnspython 2.0 in favor of `resolve()`) — and fixes a real bug: bare `raise`
statements used outside any `except` block, which raise `RuntimeError: No active
exception to re-raise` instead of a meaningful error. These are now explicit
exceptions.

## Changes

- **Configurable nameservers** via new `ga_dns` config (env `GA_DNS`). Empty
  (the code default) means "use the pod/system resolver" (e.g. CoreDNS). Accepts
  a comma-separated string or list; each entry may include a port, e.g.
  `8.8.8.8:53` or `[2001:4860:4860::8888]:53`.
- **`utils/net.py`**: parses/validates `ip[:port]` nameservers (IPv4/IPv6),
  dropping invalid entries with a warning rather than failing hard. Uses
  `NoDecode` + a before-validator so `GA_DNS=8.8.8.8:53` isn't JSON-decoded by
  pydantic-settings before validation.
- **`ga4/client.py`**: builds a per-server `Do53Nameserver` (dnspython's
  `nameservers` list can't carry a port); only installs the DNS adapter when
  `ga_dns` is set. Fixes the `query()`→`resolve()` call and replaces bare
  `raise` with explicit exceptions.
- **Helm**: adds `analytics.gaDnsNameservers` (plus a `global` override) and
  wires `GA_DNS` into the controller StatefulSet and node DaemonSet; regenerates
  the chart README.

## Backward compatibility

The Helm chart default is `analytics.gaDnsNameservers: "8.8.8.8:53"`, so existing
installs keep the previous behavior. Operators can set it to `""` to use the
cluster's default resolver (CoreDNS), or point it at a specific resolver.

## Testing

- Added unit tests in `rawfile/tests/test_net.py` covering `split_host_port`
  and `parse_nameservers` (IPv4/IPv6, ports, comma-strings, lists, empty →
  disabled, invalid → dropped-with-warning, and a `NoDecode` regression guard).
- `pre-commit run --all-files` clean.

## Notes for reviewers

- IPv6 support is for the **nameserver address** only; endpoint resolution is
  A-record (IPv4). 
