### PR TITLE
:bug: Use findmnt with more stable output instead of using mount

### DIFF
--- a/rawfile/filesystem/utils.py
+++ b/rawfile/filesystem/utils.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 from pathlib import Path
 from utils.commands import run
@@ -14,13 +15,15 @@ def get_device_fs(device: str) -> str | None:
 def get_device_for_mountpoint(mountpoint: str) -> str | None:
     try:
         output = run(
-            f"mount | grep 'on {mountpoint}'",
+            f"findmnt -no SOURCE --mountpoint {mountpoint}",
             check=True,
             capture_output=True,
         )
     except subprocess.CalledProcessError:
         return None
-    lines = output.stdout.decode().strip().splitlines()
-    if not len(lines):
+    source = output.stdout.decode().strip()
+    if not source:
         return None
-    return Path(lines[0].split(" ")[0].strip()).resolve().as_posix()
+    # Strip bind-mount subpath notation, "/dev/loop1[/default]" -> "/dev/loop1"
+    device = re.sub(r"\[.*\]$", "", source)
+    return Path(device).resolve().as_posix()


### PR DESCRIPTION
Resolves #370

Since I have a much newer kernel, Tested with

```
> truncate -s 10GiB ./file
> mkfs.xfs ./file
 meta-data=./file                 isize=512    agcount=4, agsize=655360 blks
          =                       sectsz=512   attr=2, projid32bit=1
          =                       crc=1        finobt=1, sparse=1, rmapbt=1
          =                       reflink=1    bigtime=1 inobtcount=1 nrext64=1
          =                       exchange=1   metadir=0
 data     =                       bsize=4096   blocks=2621440, imaxpct=25
          =                       sunit=0      swidth=0 blks
 naming   =version 2              bsize=4096   ascii-ci=0, ftype=1, parent=1
 log      =internal log           bsize=4096   blocks=16384, version=2
          =                       sectsz=512   sunit=0 blks, lazy-count=1
 realtime =none                   extsz=4096   blocks=0, rtextents=0
          =                       rgcount=0    rgsize=0 extents
          =                       zoned=0      start=0 reserved=0
> mount ./file /mnt
> findmnt -no SOURCE --mountpoint /mnt
 /dev/loop0
```