### PR TITLE
feat(helm): conditional snapshot-controller with leader-election

### DIFF
--- a/deploy/helm/rawfile-localpv/README.md
+++ b/deploy/helm/rawfile-localpv/README.md
@@ -97,6 +97,7 @@ Please follow the [install guide](https://github.com/openebs/rawfile-localpv/tre
 | node.podAnnotations | object | `{}` | Annotations for the node DaemonSet pods |
 | node.priorityClassName | string | `"system-node-critical"` | priorityClassName for node component since this part is critical for node `system-node-critical` is default |
 | node.resources | object | `{}` | Sets compute resources for node component |
+| node.snapshotController.enabled | bool | `true` | Runs the snapshot-controller container. There should only be one snapshot-controller per cluster, so disable this if the cluster already runs one. That controller must be started with `--enable-distributed-snapshotting=true`, or rawfile snapshots will never be provisioned. Requires `capabilities.snapshots.enabled`. |
 | node.snapshotController.image.pullPolicy | string | `nil` | Image pull policy for `snapshot-controller` |
 | node.snapshotController.image.registry | string | `""` | Image Registry for `snapshot-controller` |
 | node.snapshotController.image.repository | string | `"sig-storage/snapshot-controller"` | Image Repository for `snapshot-controller` |

--- a/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
+++ b/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
@@ -281,11 +281,13 @@ spec:
           resources:
             {{- include "rawfile-localpv.node-external-snapshotter-resources" . | nindent 12 }}
         {{- end }}
-        {{- if .Values.capabilities.snapshots.enabled }}
+        {{- if and .Values.capabilities.snapshots.enabled .Values.node.snapshotController.enabled }}
         - name: snapshot-controller
           args:
             - "--v=2"
             - "--enable-distributed-snapshotting=true"
+            # runs as Daemonset, but only one should be active per cluster
+            - "--leader-election=true"
           resources:
             {{- include "rawfile-localpv.node-snapshot-controller-resources" . | nindent 12 }}
           image: {{ include "rawfile-localpv.common.image" (dict "imageRoot" .Values.node.snapshotController.image "csiSideCars" .Values.csiSideCars.image "global" .Values.global) | quote }}

--- a/deploy/helm/rawfile-localpv/templates/rbac.yaml
+++ b/deploy/helm/rawfile-localpv/templates/rbac.yaml
@@ -150,6 +150,10 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots/status"]
     verbs: ["update", "patch"]
+  # Leader election for the snapshot-controller.
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/helm/rawfile-localpv/values.yaml
+++ b/deploy/helm/rawfile-localpv/values.yaml
@@ -149,6 +149,11 @@ node:
       pullPolicy:
 
   snapshotController:
+    # -- Runs the snapshot-controller container. There should only be one snapshot-controller per cluster,
+    # so disable this if the cluster already runs one. That controller must be started with
+    # `--enable-distributed-snapshotting=true`, or rawfile snapshots will never be provisioned.
+    # Requires `capabilities.snapshots.enabled`.
+    enabled: true
     # -- Sets compute resources for snapshot-controller container
     resources: {}
     image:


### PR DESCRIPTION
Copy of https://github.com/openebs/zfs-localpv/pull/742. Allows disabling the snapshot-controller in the helm values; there should be only one snapshot-controller run in a cluster. See the conversation there for more details.

In a daemonset across multiple nodes multiple snapshot-controllers would still be running, this PR also unconditionally enables leader-election on the snapshot-controller to fix that. 