### PR TITLE
Nightly ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - develop
       - "release/**"
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
   changes:

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -1,0 +1,16 @@
+name: Nightly CI
+on:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+  nightly-ci:
+    if: ${{ success() }}
+    needs:
+      - ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI succeeded
+        run: exit 0


### PR DESCRIPTION
    ci: nightly from common repo
    
    We'll schedule all nightly's from a common repo.
    Then we can see all results in common page.
