### PR TITLE
Fix CopyOnWrite auto-detection

### DIFF
--- a/.ci/common
+++ b/.ci/common
@@ -34,6 +34,10 @@ else
 	export TAG_SUFFIX="-ci"
 fi
 
+# override this for easy testing of a release tag
+#export CI_TEST_IMAGE_TAG="v0.15.0"
+#export TAG_SUFFIX=""
+
 build-image-tag() {
 	printf "%s%s" "${1}" "${TAG_SUFFIX:-}"
 }

--- a/.ci/deployer.sh
+++ b/.ci/deployer.sh
@@ -6,8 +6,7 @@ SCRIPT_DIR="$(dirname "$0")"
 
 source "${SCRIPT_DIR}/common"
 
-TMP_KIND=${TMP_KIND:-"/tmp/kind/rawfile/"}
-TMP_KIND_CONFIG="$TMP_KIND/config.yaml"
+CLUSTER_NAME="rawfile"
 WORKERS=1
 DRY_RUN=
 KIND="kind"
@@ -17,6 +16,7 @@ CLEANUP="false"
 SUDO=${SUDO:-"sudo"}
 RAW_SIZE="100GiB"
 K8S_VERSION=$(cat "$SCRIPT_DIR/../.kube-version")
+INS_SSH="true"
 
 command -v "$KIND" >/dev/null 2>&1 || die "kind is not installed. Aborting."
 command -v "$KUBECTL" >/dev/null 2>&1 || die "kubectl is not installed. Aborting."
@@ -31,6 +31,8 @@ Options:
   --dry-run                         Don't do anything, just output steps.
   --cleanup                         Prior to starting, stops the running instance of the deployer.
   --loop-size     <size>            Size of the rawfile backend for each worker node (Default: $RAW_SIZE).
+  --name          <string>          Name of the cluster to issue commands on.
+  --no-ssh                          Don't install SSH on the worker nodes (Default: false).
 
 Command:
   start                             Start the k8s cluster.
@@ -65,6 +67,16 @@ while [ "$#" -gt 0 ]; do
 	*)
 		[ -z "$DO_ARGS" ] && die "Must specify command before args"
 		case $1 in
+		--name)
+			shift
+			test $# -lt 1 && die "Missing Name of the Cluster"
+			CLUSTER_NAME=$1
+			shift
+			;;
+		--no-ssh)
+			INS_SSH="false"
+			shift
+			;;
 		--workers)
 			shift
 			test $# -lt 1 && die "Missing Number of Workers"
@@ -100,12 +112,15 @@ while [ "$#" -gt 0 ]; do
 	esac
 done
 
+TMP_KIND=${TMP_KIND:-"/tmp/kind/$CLUSTER_NAME"}
+TMP_KIND_CONFIG="$TMP_KIND/config.yaml"
+
 if [ -z "$COMMAND" ]; then
 	die "No command specified!\n$(help)"
 fi
 
 if [ "$COMMAND" = "stop" ] || [ "$CLEANUP" = "true" ]; then
-	$KIND delete cluster --name "rawfile"
+	$KIND delete cluster --name "$CLUSTER_NAME"
 	if [ "$COMMAND" = "stop" ]; then
 		exit 0
 	fi
@@ -134,9 +149,9 @@ start_core=1
 nodes=()
 for node_index in $(seq 1 $WORKERS); do
 	if [ "$node_index" == 1 ]; then
-		node="rawfile-worker"
+		node="$CLUSTER_NAME-worker"
 	else
-		node="rawfile-worker$node_index"
+		node="$CLUSTER_NAME-worker$node_index"
 	fi
 	nodes+=($node)
 
@@ -169,13 +184,12 @@ if [ -n "$DRY_RUN" ]; then
 	cat "$TMP_KIND_CONFIG"
 fi
 
-$KIND create cluster --config "$TMP_KIND_CONFIG" --name "rawfile"
+$KIND create cluster --config "$TMP_KIND_CONFIG" --name "$CLUSTER_NAME"
 
-$KUBECTL cluster-info --context kind-rawfile
-if [ -z "$DRY_RUN" ]; then
-	host_ip=$($DOCKER network inspect kind | jq -r 'first (.[0].IPAM.Config[].Gateway | select(.))')
-fi
-echo "HostIP: $host_ip"
+export KUBECONFIG="$TMP_KIND/kubeconfig"
+$KIND export kubeconfig --name "$CLUSTER_NAME"
+
+$KUBECTL cluster-info --context "kind-$CLUSTER_NAME"
 
 # shellcheck disable=SC2068
 for node in ${nodes[@]}; do
@@ -183,9 +197,9 @@ for node in ${nodes[@]}; do
 
 	$DOCKER exec "$node" sh -c "mkdir /var/local/openebs/rawfile/default-pool; mount /var/local/openebs/rawfile/default-pool.img /var/local/openebs/rawfile/default-pool"
 
-	# Note: this will go away if the node restarts...
-	$DOCKER exec "$node" bash -c 'printf "'"$host_ip"' kvmhost\n" >> /etc/hosts'
-
+	if [ "$INS_SSH" = "false" ]; then
+		continue
+	fi
 	# SSH access is required by the e2e test disruptive storage tests
 	$DOCKER exec "$node" apt update
 	$DOCKER exec "$node" apt install -y -q openssh-server
@@ -194,3 +208,7 @@ for node in ${nodes[@]}; do
 	$DOCKER cp "$node":/etc/ssh/ssh_host_rsa_key "$SCRIPT_DIR/e2e-test/ssh_id"
 	$DOCKER exec "$node" systemctl restart sshd
 done
+
+echo
+echo "You can use the following command to restrict your KUBECONFIG to this cluster:"
+echo "export KUBECONFIG=\"$TMP_KIND/kubeconfig\""

--- a/.ci/e2e-test/setup.sh
+++ b/.ci/e2e-test/setup.sh
@@ -20,8 +20,9 @@ if [ -n "${CI_RELEASE_TAG:-}" ]; then
 	docker pull "$URI"
 fi
 
-if [ "$(kubectl config current-context)" = "kind-rawfile" ]; then
-	kind load docker-image "$URI" --name "rawfile"
+CLUSTER_NAME="$(kubectl config current-context)"
+if [[ "$CLUSTER_NAME" =~ ^kind-rawfile.* ]]; then
+	kind load docker-image "$URI" --name "${CLUSTER_NAME#kind-}"
 fi
 
 CHART="$SCRIPT_DIR/../../deploy/helm/rawfile-localpv/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added ✨
 
 - Add Support for setting Compute Resources for API Server
+- Add documentation for async volume replication with [VolSync](https://volsync.readthedocs.io/)
 
 ### Fixed 🐛
 
+- StorageClass CopyOnWrite with value `""` now correctly defaults to auto-detected as opposed to `false`
+
 ### Changed ♻️
+
+- StorageClass and VolumeSnapshotClass are now updatable with helm upgrade command
 
 ### Removed 🗑️ ⚠️
 
 ### Internal 🔧
+
+- Support for creating multiple local [kind](https://kind.sigs.k8s.io/) rawfile clusters
 
 ### Known Issues 🚫
 

--- a/deploy/helm/rawfile-localpv/templates/snapshotclass.yaml
+++ b/deploy/helm/rawfile-localpv/templates/snapshotclass.yaml
@@ -6,7 +6,7 @@ kind: VolumeSnapshotClass
 metadata:
   name: {{ $class.name }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
     {{- if $class.isDefault }}snapshot.storage.kubernetes.io/is-default-class: "true"{{ end }}
 driver: {{ $vals.provisionerName }}

--- a/deploy/helm/rawfile-localpv/templates/storageclass.yaml
+++ b/deploy/helm/rawfile-localpv/templates/storageclass.yaml
@@ -6,7 +6,7 @@ kind: StorageClass
 metadata:
   name: {{ $class.name }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
     {{ if $class.isDefault }}storageclass.kubernetes.io/is-default-class: "true"{{ end }}
 provisioner: {{ $vals.provisionerName }}

--- a/deploy/helm/rawfile-localpv/templates/storageclass.yaml
+++ b/deploy/helm/rawfile-localpv/templates/storageclass.yaml
@@ -19,7 +19,7 @@ parameters:
   csi.storage.k8s.io/fstype: {{ $class.fsType | default "ext4" }}
   thinProvision: {{ $class.thinProvision | default "false" | toString | quote }}
   formatOptions: {{ ($class.formatOptions | default (list)) | join " " | quote }}
-  copyOnWrite: {{ $class.copyOnWrite | default "false" | toString | quote }}
+  copyOnWrite: {{ $class.copyOnWrite | toString | quote }}
   freezeFs: {{ $class.freezeFs | default "false" | toString | quote }}
   {{- with $class.storagePool }}
   storagePool: {{ . }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ snapshots, cloning, expansion and rich metrics.
 - [Cloning Volumes](./user-guide/cloning.md) — PVC-to-PVC copies
 - [Resizing Volumes](./user-guide/resize.md) — online volume expansion
 - [Storage Pools](./user-guide/storage-pools.md) — multiple pools, capacity reservation, tiering
+- [Async Replication with VolSync](./user-guide/replication.md) — cross-node/cross-cluster replication
 
 ### Reference
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -113,7 +113,9 @@ a pool via the `storagePool` parameter, enabling storage tiering. See
 ## Current limitations
 
 - Volumes are strictly node-local — no replication; node loss means data loss for
-  volumes on that node.
+  volumes on that node. For cross-node/cross-cluster async replication, see
+  [Async Replication with VolSync](./user-guide/replication.md) (`Filesystem`-mode
+  volumes only — `Block` mode isn't replicable end-to-end by any VolSync mover today).
 - `ReadWriteOnce` only; `readOnly` attribute of block PVCs not honored.
 - No shrinking.
 - Cross-node cloning not yet available.

--- a/docs/user-guide/replication.md
+++ b/docs/user-guide/replication.md
@@ -1,0 +1,147 @@
+# User Guide: Async Replication with VolSync
+
+RawFile LocalPV volumes are strictly **node-local** — the driver itself has no
+replication (see [Features § Current limitations](../features.md#current-limitations)).
+For cross-node or cross-cluster async replication / DR, pair it with
+[VolSync](https://volsync.readthedocs.io/), a Kubernetes operator that copies PVC data
+via a `ReplicationSource` (on the source) and a `ReplicationDestination` (on the
+destination) using a pluggable "mover".
+
+This guide covers what actually works with RawFile LocalPV today, and the gotchas that
+aren't obvious from VolSync's own docs.
+
+## Before you begin
+
+- VolSync installed on **both** sides (same cluster+different namespace, or two separate
+  clusters — VolSync itself must be running wherever each CR lives).
+- Snapshots enabled on RawFile LocalPV (chart default: `capabilities.snapshots.enabled=true`)
+  — needed for `copyMethod: Snapshot`, the recommended copy method (see
+  [Snapshots & Restore](./snapshots.md)).
+- A `VolumeSnapshotClass` and `StorageClass` for the driver (chart default: both named
+  `rawfile-localpv`).
+
+### Block volumes don't work yet
+
+This isn't a RawFile LocalPV-specific issue.
+
+See [backube/volsync discussion #495](https://github.com/backube/volsync/discussions/495)
+and [issue #556](https://github.com/backube/volsync/issues/556) for upstream status.
+
+## Step 1 — Set up the destination
+
+```yaml
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationDestination
+metadata:
+  name: app-data-dst
+spec:
+  rsync:
+    copyMethod: Snapshot
+    capacity: 10Gi
+    accessModes: ["ReadWriteOnce"]
+    storageClassName: rawfile-localpv
+    volumeSnapshotClassName: rawfile-localpv
+    # NodePort (or LoadBalancer) needed if the source can't reach a ClusterIP —
+    # see "Reaching the destination" below.
+    serviceType: NodePort
+```
+
+```shell
+kubectl apply -f replicationdestination.yaml
+```
+
+VolSync immediately provisions a **working/cache PVC** (named `<name>-dst` by default)
+and starts the mover's server side — this happens *before* any data has synced, so a
+freshly-`Bound` PVC with an empty filesystem is expected, not a sign of success yet.
+Once a sync completes, `status.latestImage` points at a `VolumeSnapshot` of that PVC —
+that snapshot, not the live cache PVC, is the point-in-time copy you should restore from.
+
+> [!IMPORTANT]
+> The dynamically-provisioned destination PVC and its `latestImage` snapshots are owned
+> by the `ReplicationDestination` and are **deleted automatically if you delete it** —
+> this is documented, intentional VolSync behavior, not a bug. If you need the replicated
+> data to survive deleting/recreating the CR, pre-create your own PVC and reference it via
+> `spec.rsync.destinationPVC` instead of letting VolSync provision one.
+
+## Step 2 — Get the address, port, and SSH key secret
+
+```shell
+kubectl get replicationdestination app-data-dst -o jsonpath='{.status.rsync}'
+```
+
+> [!WARNING]
+> `status.rsync.address` is the Service's **ClusterIP** — it's populated regardless of
+> `serviceType`, and is only reachable from inside the destination's own cluster. If
+> you're replicating across clusters (or otherwise can't route to a ClusterIP), you must
+> work out a reachable address yourself: check the actual `Service` object for the
+> assigned `NodePort` (`kubectl get svc <name>-rsync-dst`, port shown as `22:<nodePort>/TCP`),
+> then pair it with any node address that's actually routable from the source side (e.g.
+> two `kind` clusters on the same Docker network share node container IPs).
+
+VolSync also generates an SSH keypair, split across three secrets
+(`<name>-main-...`, `<name>-dest-...`, `<name>-src-...`). Copy the `-src-` one — it's
+what the source side needs — to wherever the `ReplicationSource` will run:
+
+```shell
+kubectl get secret <name>-src-<name> -o json \
+  | jq '{apiVersion, kind, type, data, metadata: {name: .metadata.name, namespace: "<source-namespace>"}}' \
+  | kubectl --context <source-context> apply -f -
+```
+
+## Step 3 — Set up the source
+
+```yaml
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: app-data-src
+spec:
+  sourcePVC: app-data
+  trigger:
+    schedule: "*/30 * * * *"   # or `manual: <any-string>` for one-off syncs
+  rsync:
+    copyMethod: Snapshot
+    volumeSnapshotClassName: rawfile-localpv
+    address: <reachable-address-from-step-2>
+    port: <nodePort-from-step-2>
+    sshKeys: <name>-src-<name>   # the secret copied in step 2
+```
+
+```shell
+kubectl apply -f replicationsource.yaml
+```
+
+> [!WARNING]
+> `sshKeys` is easy to skip by accident — if omitted, VolSync doesn't fail, it silently
+> **generates its own unrelated keypair** for that side. Both sides then have
+> self-consistent-looking but mutually-untrusting keys, and every sync attempt fails with
+> `Host key verification failed` (or a repeating "accepted, then immediately disconnected"
+> pattern if only the client key mismatches) — with no indication in `kubectl get
+> replicationsource/replicationdestination` beyond a stuck `SyncInProgress`. Always set
+> `sshKeys` explicitly on whichever side didn't generate the keys.
+
+## Verifying a sync
+
+```shell
+kubectl get replicationsource app-data-src -o jsonpath='{.status.latestMoverStatus}'
+kubectl get replicationdestination app-data-dst -o jsonpath='{.status.latestImage}'
+```
+
+A successful sync shows `"result": "Successful"` and, on the destination, an updated
+`latestImage` `VolumeSnapshot` name.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `VolumeSnapshot` stuck not `readyToUse`, mover pod not yet started | Normal if the source PVC is actively mounted/written — the driver retries `CreateSnapshot` (`SnapshotCreateVolumeInUse`) until the volume is briefly idle. See [Snapshots & Restore](./snapshots.md#step-1--take-a-snapshot). |
+| `Host key verification failed` in mover pod logs | The source's `sshKeys` secret doesn't match the destination's — see the warning in Step 3. Delete the source's self-generated `-main-`/`-dest-`/`-src-` secrets and the `ReplicationSource`, re-copy the destination's `-src-` secret, and re-apply with `sshKeys` set explicitly. |
+| SSH auth succeeds but sync still fails, e.g. `truncate ... invalid argument` | You're replicating a `volumeMode: Block` PVC — not supported end-to-end today, see [Block volumes don't work yet](#block-volumes-dont-work-yet). Switch to `Filesystem` mode. |
+| Sync never starts across clusters/networks | `status.rsync.address` is a ClusterIP, not reachable externally — use a `NodePort`/`LoadBalancer` Service and a manually-determined reachable address (Step 2). |
+| Destination PVC/snapshot disappeared after deleting `ReplicationDestination` | Expected — dynamically-provisioned destination resources are owned by the CR. Use `destinationPVC` for data you need to survive CR deletion. |
+
+## Related guides
+
+- [Snapshots & Restore](./snapshots.md)
+- [Creating and Configuring Volumes](./volumes.md)
+- [VolSync documentation](https://volsync.readthedocs.io/)

--- a/rawfile/rawfile_servicer.py
+++ b/rawfile/rawfile_servicer.py
@@ -216,7 +216,7 @@ class RawFileControllerServicer(csi_pb2_grpc.ControllerServicer):
         params = normalize_parameters(request.parameters)
         thin_provision = str_to_bool(params.get("thinprovision", "no"))
         format_options = params.get("formatoptions", "").strip()
-        copy_on_write_param = params.get("copyonwrite", None)
+        copy_on_write_param = params.get("copyonwrite", None) or None
         copy_on_write = None
         if copy_on_write_param is not None:
             copy_on_write = str_to_bool(copy_on_write_param)


### PR DESCRIPTION
    docs: add async DR using snapshots (volsync)

    Adds a simple doc for setting up volsync for DR usecase.

---

    test: allow creating multiple rawfile clusters
    
    By specifying a name we can actually create multiple clusters, which can be
    useful for testing multi-cluster environments.
    
---

    fix(chart): allow updating storage-class by editing the values
    
    I'm not sure if this had been intentional, needs review.
    
---

    fix(chart): don't default copy_on_write to false
    
    Let the rawfile auto-detect the cow as expected and documented.
    
---

    fix: handle copy_on_write as "" same as not present
    
    When copy_on_write is not present, then it defaults to auto-detect.
    A copy_on_write with "" should also default to auto-detect.
