### PR TITLE
Add Helm chart value to optionally disable strict SSL verification

### DIFF
--- a/deploy/helm/rawfile-localpv/README.md
+++ b/deploy/helm/rawfile-localpv/README.md
@@ -30,7 +30,7 @@ Please follow the [install guide](https://github.com/openebs/rawfile-localpv/tre
 | analytics.gaDnsNameservers | string | `"8.8.8.8:53"` | Comma-separated DNS nameservers (each optionally `ip:port`) used to resolve the analytics endpoint. Leave empty to use the cluster's default resolver (CoreDNS). |
 | auth.enabled | bool | `true` | Enables authentication for internal gRPC server |
 | auth.secretName | string | `""` | If managing secrets outside the chart, use this to reference the secret name; otherwise, leave empty. |
-| auth.token | string | `""` | Sets authentication token for internal gRPC server, will generate one if nothing provided |
+| auth.token | string | `""` | Sets authentication token for internal gRPC server, will generate one if nothing provided. Must be base64-encoded if provided |
 | capabilities.apiServer.enabled | bool | `true` | Sets whether API Server has been enabled or not |
 | capabilities.resize.enabled | bool | `true` | Sets whether volume resizing is enabled. If disabled, don't deploy controller component |
 | capabilities.snapshots.enabled | bool | `true` | Sets whether taking volume snapshots is enabled. Required for volume cloning. Runs externalSnapshotter and snapshotController containers. |
@@ -124,3 +124,4 @@ Please follow the [install guide](https://github.com/openebs/rawfile-localpv/tre
 | storageClasses[0].storagePool | string | `""` | Sets storage pool used for volumes |
 | storageClasses[0].thinProvision | string | `""` | Enables thin provisioning of volumes |
 | storageClasses[0].volumeBindingMode | string | `"WaitForFirstConsumer"` | Sets volumeBindingMode for StorageClass |
+| tls.insecureSkipVerify | bool | `false` | Skips strict x509 TLS verification when the driver's Kubernetes client talks to the API server if true. Dangerous: do not set to true if you are not sure of the implications |

--- a/deploy/helm/rawfile-localpv/templates/controller/deployment.yaml
+++ b/deploy/helm/rawfile-localpv/templates/controller/deployment.yaml
@@ -45,6 +45,8 @@ spec:
               value: {{ .Values.logLevel }}
             - name: LOG_FORMAT
               value: {{ .Values.logFormat }}
+            - name: TLS_INSECURE_SKIP_VERIFY
+              value: "{{ .Values.tls.insecureSkipVerify }}"
             - name: GA_ENABLED
               {{- if kindIs "bool" .Values.global.analytics.enabled }}
               value: "{{ .Values.global.analytics.enabled }}"
@@ -104,6 +106,8 @@ spec:
               value: {{ .Values.logLevel }}
             - name: LOG_FORMAT
               value: {{ .Values.logFormat }}
+            - name: TLS_INSECURE_SKIP_VERIFY
+              value: "{{ .Values.tls.insecureSkipVerify }}"
             - name: CSI_DRIVER__PLUGIN_TYPE
               value: controller
             - name: CSI_DRIVER__GRPC_WORKERS

--- a/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
+++ b/deploy/helm/rawfile-localpv/templates/node-plugin/daemonset.yaml
@@ -165,6 +165,8 @@ spec:
               value: "{{ .Values.capabilities.snapshots.enabled }}"
             - name: CSI_DRIVER__CAPABILITIES__RESIZE__ENABLED
               value: "{{ .Values.capabilities.resize.enabled }}"
+            - name: TLS_INSECURE_SKIP_VERIFY
+              value: "{{ .Values.tls.insecureSkipVerify }}"
           ports:
             - name: metrics
               containerPort: {{ .Values.metrics.port }}

--- a/deploy/helm/rawfile-localpv/values.yaml
+++ b/deploy/helm/rawfile-localpv/values.yaml
@@ -31,7 +31,7 @@ logFormat: json
 auth:
   # -- Enables authentication for internal gRPC server
   enabled: true
-  # -- Sets authentication token for internal gRPC server, will generate one if nothing provided
+  # -- Sets authentication token for internal gRPC server, will generate one if nothing provided. Must be base64-encoded if provided
   token: ""
   # -- If managing secrets outside the chart, use this to reference the secret name; otherwise, leave empty.
   secretName: ""
@@ -293,3 +293,7 @@ capabilities:
   apiServer:
     # -- Sets whether API Server has been enabled or not
     enabled: true
+
+tls:
+  # -- Skips strict x509 TLS verification when the driver's Kubernetes client talks to the API server if true. Dangerous: do not set to true if you are not sure of the implications
+  insecureSkipVerify: false

--- a/rawfile/config/model.py
+++ b/rawfile/config/model.py
@@ -245,6 +245,10 @@ class RawFileCmd(
         default=LoggingFormats.JSON,
         description="Logging format set it to pretty for a human-readable format",
     )
+    tls_insecure_skip_verify: bool = Field(
+        default=False,
+        description="Disables strict x509 TLS verification when talking to the Kubernetes API server if true. Dangerous: do not enable unless you understand the implications",
+    )
     ga_enabled: bool = Field(
         default=False,
         description="Enable Google Analytics metrics",

--- a/rawfile/orchestrator/k8s.py
+++ b/rawfile/orchestrator/k8s.py
@@ -33,6 +33,12 @@ def load_config(func):
                 k8s_config.load_incluster_config()
             else:
                 k8s_config.load_config()
+
+            if config.tls_insecure_skip_verify:
+                configuration = k8s_client.Configuration.get_default_copy()
+                configuration.verify_ssl = False
+                k8s_client.Configuration.set_default(configuration)
+
             __config_loaded = True
         return func(*args, **kwargs)
 


### PR DESCRIPTION
Optionally disables TLS verification when running in environments with malformed Kubernetes API server certificates.